### PR TITLE
Stop spwaning new thread if there were no events in cycle

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -127,6 +127,12 @@ fn main() -> Result<(), Box<dyn Error>> {
     let mut now = Instant::now();
 
     fn flush(registry: Registry, config: Arc<Config>) -> Registry {
+        if registry.is_empty() {
+            log::info!("Registry is empty, nothing to aggregate");
+
+            return registry;
+        }
+
         let new_registry = registry.new_with_gauges();
 
         thread::spawn(move || {

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -136,6 +136,12 @@ pub struct Registry {
 }
 
 impl Registry {
+    pub fn is_empty(&self) -> bool {
+        self.counters.is_empty() && self.gauges.is_empty() && self.timings.is_empty()
+    }
+}
+
+impl Registry {
     pub fn add(&mut self, metric: &Metric) -> bool {
         match &metric.kind {
             MetricKind::Counter(value) => self


### PR DESCRIPTION
If we know there is nothing to aggregate, there is no need to spawn a new thread.