### PR TITLE
Add overflowing metric in new registry

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -240,6 +240,8 @@ fn main() -> Result<(), Box<dyn Error>> {
 
                         registry = flush(registry, config.clone());
                         now = Instant::now();
+
+                        registry.add(&metric);
                     }
                 }
             }


### PR DESCRIPTION
If overflow for a metric is detected, everything until now is flushed, but we did not add overflowing metric into new registry.