### PR TITLE
Remove average from statistics

### DIFF
--- a/src/backend/console.rs
+++ b/src/backend/console.rs
@@ -29,7 +29,6 @@ impl Backend for Console {
                 logger.info(&format!("  {name}"));
                 logger.info(&format!("    count: {}", stats.count()));
                 logger.info(&format!("    sum: {}", stats.sum()));
-                logger.info(&format!("    avg: {}", stats.average()));
                 logger.info(&format!("    std: {}", stats.std()));
                 logger.info(&format!("    median: {}", stats.median()));
                 logger.info(&format!("    p75: {}", stats.percentile(0.75)));
@@ -44,7 +43,6 @@ impl Backend for Console {
                 logger.info(&format!("  {name}"));
                 logger.info(&format!("    count: {}", stats.count()));
                 logger.info(&format!("    sum: {}", stats.sum()));
-                logger.info(&format!("    avg: {}", stats.average()));
                 logger.info(&format!("    std: {}", stats.std()));
                 logger.info(&format!("    median: {}", stats.median()));
                 logger.info(&format!("    p75: {}", stats.percentile(0.75)));

--- a/src/backend/elastic.rs
+++ b/src/backend/elastic.rs
@@ -79,7 +79,6 @@ impl Backend for ElasticSearch {
                 HashMap::from([
                     (format!("counter.{name}.count"), stats.count().into()),
                     (format!("counter.{name}.sum"), stats.sum().into()),
-                    (format!("counter.{name}.avg"), stats.average().into()),
                     (format!("counter.{name}.std"), stats.std().into()),
                     (format!("counter.{name}.median"), stats.median().into()),
                     (format!("counter.{name}.p75"), stats.percentile(0.75).into()),
@@ -98,7 +97,6 @@ impl Backend for ElasticSearch {
                 HashMap::from([
                     (format!("timing.{name}.count"), stats.count().into()),
                     (format!("timing.{name}.sum"), stats.sum().into()),
-                    (format!("timing.{name}.avg"), stats.average().into()),
                     (format!("timing.{name}.std"), stats.std().into()),
                     (format!("timing.{name}.median"), stats.median().into()),
                     (format!("timing.{name}.p75"), stats.percentile(0.75).into()),

--- a/src/backend/postgresql.rs
+++ b/src/backend/postgresql.rs
@@ -105,14 +105,6 @@ impl Backend for PostgreSQL {
                 time,
                 &time_frame.host,
                 MetricKind::Counter,
-                &format!("{name}.avg"),
-                stats.average(),
-                &logger,
-            );
-            self.insert(
-                time,
-                &time_frame.host,
-                MetricKind::Counter,
                 &format!("{name}.std"),
                 stats.std(),
                 &logger,
@@ -160,14 +152,6 @@ impl Backend for PostgreSQL {
                 MetricKind::Timing,
                 &format!("{name}.sum"),
                 stats.sum() as f64,
-                &logger,
-            );
-            self.insert(
-                time,
-                &time_frame.host,
-                MetricKind::Timing,
-                &format!("{name}.avg"),
-                stats.average(),
                 &logger,
             );
             self.insert(

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -67,10 +67,6 @@ impl Statistics {
         self.list.len()
     }
 
-    pub fn average(&self) -> f64 {
-        self.sum as f64 / self.list.len() as f64
-    }
-
     pub fn median(&self) -> f64 {
         let len = self.list.len();
 


### PR DESCRIPTION
Average can always be calculated from `sum` and `count`.

Closes https://github.com/zlikavac32/metco/issues/9