### PR TITLE
Provide min/max metrics

### DIFF
--- a/src/backend/console.rs
+++ b/src/backend/console.rs
@@ -33,6 +33,14 @@ impl Backend for Console {
                 logger.info(&format!("    median: {}", stats.median()));
                 logger.info(&format!("    p75: {}", stats.percentile(0.75)));
                 logger.info(&format!("    p90: {}", stats.percentile(0.90)));
+
+                if let Some(min) = stats.min() {
+                    logger.info(&format!("    min: {}", min));
+                }
+
+                if let Some(max) = stats.max() {
+                    logger.info(&format!("    max: {}", max));
+                }
             });
         }
 
@@ -47,6 +55,14 @@ impl Backend for Console {
                 logger.info(&format!("    median: {}", stats.median()));
                 logger.info(&format!("    p75: {}", stats.percentile(0.75)));
                 logger.info(&format!("    p90: {}", stats.percentile(0.90)));
+
+                if let Some(min) = stats.min() {
+                    logger.info(&format!("    min: {}", min));
+                }
+
+                if let Some(max) = stats.max() {
+                    logger.info(&format!("    max: {}", max));
+                }
             });
         }
     }

--- a/src/backend/elastic.rs
+++ b/src/backend/elastic.rs
@@ -73,37 +73,47 @@ impl Backend for ElasticSearch {
         });
 
         time_frame.counters.iter().for_each(|(name, stats)| {
-            self.insert(
-                time,
-                &time_frame.host,
-                HashMap::from([
-                    (format!("counter.{name}.count"), stats.count().into()),
-                    (format!("counter.{name}.sum"), stats.sum().into()),
-                    (format!("counter.{name}.std"), stats.std().into()),
-                    (format!("counter.{name}.median"), stats.median().into()),
-                    (format!("counter.{name}.p75"), stats.percentile(0.75).into()),
-                    (format!("counter.{name}.p90"), stats.percentile(0.90).into()),
-                ]),
-                &logger,
-            );
+            let mut map = HashMap::from([
+                (format!("counter.{name}.count"), stats.count().into()),
+                (format!("counter.{name}.sum"), stats.sum().into()),
+                (format!("counter.{name}.std"), stats.std().into()),
+                (format!("counter.{name}.median"), stats.median().into()),
+                (format!("counter.{name}.p75"), stats.percentile(0.75).into()),
+                (format!("counter.{name}.p90"), stats.percentile(0.90).into()),
+            ]);
+
+            if let Some(min) = stats.min() {
+                map.insert(format!("counter.{name}.min"), min.into());
+            }
+
+            if let Some(max) = stats.max() {
+                map.insert(format!("counter.{name}.max"), max.into());
+            }
+
+            self.insert(time, &time_frame.host, map, &logger);
 
             logger.debug(&format!("Processed counter {name}"));
         });
 
         time_frame.timings.iter().for_each(|(name, stats)| {
-            self.insert(
-                time,
-                &time_frame.host,
-                HashMap::from([
-                    (format!("timing.{name}.count"), stats.count().into()),
-                    (format!("timing.{name}.sum"), stats.sum().into()),
-                    (format!("timing.{name}.std"), stats.std().into()),
-                    (format!("timing.{name}.median"), stats.median().into()),
-                    (format!("timing.{name}.p75"), stats.percentile(0.75).into()),
-                    (format!("timing.{name}.p90"), stats.percentile(0.90).into()),
-                ]),
-                &logger,
-            );
+            let mut map = HashMap::from([
+                (format!("timing.{name}.count"), stats.count().into()),
+                (format!("timing.{name}.sum"), stats.sum().into()),
+                (format!("timing.{name}.std"), stats.std().into()),
+                (format!("timing.{name}.median"), stats.median().into()),
+                (format!("timing.{name}.p75"), stats.percentile(0.75).into()),
+                (format!("timing.{name}.p90"), stats.percentile(0.90).into()),
+            ]);
+
+            if let Some(min) = stats.min() {
+                map.insert(format!("timing.{name}.min"), min.into());
+            }
+
+            if let Some(max) = stats.max() {
+                map.insert(format!("timing.{name}.max"), max.into());
+            }
+
+            self.insert(time, &time_frame.host, map, &logger);
 
             logger.debug(&format!("Processed timing {name}"));
         });

--- a/src/backend/postgresql.rs
+++ b/src/backend/postgresql.rs
@@ -134,6 +134,28 @@ impl Backend for PostgreSQL {
                 &logger,
             );
 
+            if let Some(min) = stats.min() {
+                self.insert(
+                    time,
+                    &time_frame.host,
+                    MetricKind::Counter,
+                    &format!("{name}.min"),
+                    min as f64,
+                    &logger,
+                );
+            }
+
+            if let Some(max) = stats.max() {
+                self.insert(
+                    time,
+                    &time_frame.host,
+                    MetricKind::Counter,
+                    &format!("{name}.max"),
+                    max as f64,
+                    &logger,
+                );
+            }
+
             logger.debug(&format!("Processed counter {name}"));
         });
 
@@ -186,6 +208,28 @@ impl Backend for PostgreSQL {
                 stats.percentile(0.90) as f64,
                 &logger,
             );
+
+            if let Some(min) = stats.min() {
+                self.insert(
+                    time,
+                    &time_frame.host,
+                    MetricKind::Timing,
+                    &format!("{name}.min"),
+                    min as f64,
+                    &logger,
+                );
+            }
+
+            if let Some(max) = stats.max() {
+                self.insert(
+                    time,
+                    &time_frame.host,
+                    MetricKind::Timing,
+                    &format!("{name}.max"),
+                    max as f64,
+                    &logger,
+                );
+            }
 
             logger.debug(&format!("Processed timing {name}"));
         });

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -67,6 +67,14 @@ impl Statistics {
         self.list.len()
     }
 
+    pub fn min(&self) -> Option<u64> {
+        self.list.first().copied()
+    }
+
+    pub fn max(&self) -> Option<u64> {
+        self.list.last().copied()
+    }
+
     pub fn median(&self) -> f64 {
         let len = self.list.len();
 


### PR DESCRIPTION
It makes sense to send min/max value for counter
and timing metrics.