### PR TITLE
Tags support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Added
+
+- Tags are now supported [#15](https://github.com/zlikavac32/metco/pull/15)
+
 ### Changed
 
 - Split PostgreSQL `metrics` table into multiple [#14](https://github.com/zlikavac32/metco/pull/14)
@@ -11,6 +15,10 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 
 - Internal telemetry gauge metric name [#13](https://github.com/zlikavac32/metco/pull/13)
+
+### Removed
+
+- Hostname information is now responsibility of the client and can be sent (if needed) as a tag [#15](https://github.com/zlikavac32/metco/pull/15)
 
 ## 0.3.0 - 2025-03-11
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,18 +4,18 @@ version = 4
 
 [[package]]
 name = "addr2line"
-version = "0.22.0"
+version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e4503c46a5c0c7844e948c9a4d6acd9f50cccb4de1c48eb9e291ea17470c678"
+checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
 dependencies = [
  "gimli",
 ]
 
 [[package]]
-name = "adler"
-version = "1.0.2"
+name = "adler2"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "android-tzdata"
@@ -34,9 +34,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.14"
+version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "418c75fa768af9c03be99d17643f93f79bbba589895012a80e3452a19ddda15b"
+checksum = "3ae563653d1938f79b1ab1b5e668c87c76a9930414574a6583a7b7e11a8e6192"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -49,43 +49,44 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.7"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "038dfcf04a5feb68e9c60b21c9625a54c2c0616e79b72b0fd87075a056ae1d1b"
+checksum = "862ed96ca487e809f1c8e5a8447f6ee2cf102f846893800b20cebdf541fc6bbd"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.4"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c03a11a9034d92058ceb6ee011ce58af4a9bf61491aa7e1e59ecd24bd40d22d4"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.0.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a64c907d4e79225ac72e2a354c9ce84d50ebb4586dee56c82b3ee73004f537f5"
+checksum = "9e231f6134f61b71076a3eab506c379d4f36122f2af15a9ff04415ea4c3339e2"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.3"
+version = "3.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61a38449feb7068f52bb06c12759005cf459ee52bb4adc1d5a7c4322d716fb19"
+checksum = "3e0633414522a32ffaac8ac6cc8f748e090c5717661fddeea04219e2344f5f2a"
 dependencies = [
  "anstyle",
- "windows-sys 0.52.0",
+ "once_cell_polyfill",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "async-trait"
-version = "0.1.81"
+version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e0c28dcc82d7c8ead5cb13beb15405b57b8546e93215673ff8ca0349a028107"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -94,9 +95,9 @@ dependencies = [
 
 [[package]]
 name = "atomic"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d818003e740b63afc82337e3160717f4f63078720a810b7b903e70a5d1d2994"
+checksum = "a89cbf775b137e9b968e67227ef7f775587cde3fd31b0d8599dbd0f598a48340"
 dependencies = [
  "bytemuck",
 ]
@@ -109,23 +110,23 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
-version = "1.3.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "backtrace"
-version = "0.3.73"
+version = "0.3.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5cc23269a4f8976d0a4d2e7109211a419fe30e8d88d677cd60b6bc79c5732e0a"
+checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
 dependencies = [
  "addr2line",
- "cc",
  "cfg-if",
  "libc",
  "miniz_oxide",
  "object",
  "rustc-demangle",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -136,15 +137,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
-version = "1.3.2"
+version = "2.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "bitflags"
-version = "2.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+checksum = "34efbcccd345379ca2868b2b2c9d3782e9cc58ba87bc7d79d5b53d9c9ae6f25d"
 
 [[package]]
 name = "block-buffer"
@@ -157,15 +152,15 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.16.0"
+version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
+checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
 name = "bytemuck"
-version = "1.16.0"
+version = "1.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78834c15cb5d5efe3452d58b1e8ba890dd62d21907f867f383358198e56ebca5"
+checksum = "3995eaeebcdf32f91f980d360f78732ddc061097ab4e39991ae7a6ace9194677"
 
 [[package]]
 name = "byteorder"
@@ -175,41 +170,44 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.9.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
+checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cc"
-version = "1.0.97"
+version = "1.2.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "099a5357d84c4c61eb35fc8eafa9a79a902c2f76911e5747ced4e032edd8d9b4"
+checksum = "42bc4aea80032b7bf409b0bc7ccad88853858911b7713a8062fdc0623867bedc"
+dependencies = [
+ "shlex",
+]
 
 [[package]]
 name = "cfg-if"
-version = "1.0.0"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
 
 [[package]]
 name = "chrono"
-version = "0.4.38"
+version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
+checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
  "js-sys",
  "num-traits",
  "wasm-bindgen",
- "windows-targets 0.52.6",
+ "windows-link",
 ]
 
 [[package]]
 name = "clap"
-version = "4.5.4"
+version = "4.5.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bc066a67923782aa8515dbaea16946c5bcc5addbd668bb80af688e53e548a0"
+checksum = "2c5e4fcf9c21d2e544ca1ee9d8552de13019a42aa7dbf32747fa7aaf1df76e57"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -217,9 +215,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.2"
+version = "4.5.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae129e2e766ae0ec03484e609954119f123cc1fe650337e155d03b022f24f7b4"
+checksum = "fecb53a0e6fcfb055f686001bc2e2592fa527efaf38dbe81a6a9563562e57d41"
 dependencies = [
  "anstream",
  "anstyle",
@@ -229,11 +227,11 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.4"
+version = "4.5.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "528131438037fd55894f62d6e9f068b8f45ac57ffa77517819645d10aed04f64"
+checksum = "14cb31bb0a7d536caef2639baa7fad459e15c3144efefa6dbd1c84562c4739f6"
 dependencies = [
- "heck 0.5.0",
+ "heck",
  "proc-macro2",
  "quote",
  "syn",
@@ -241,15 +239,15 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.0"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98cc8fbded0c607b7ba9dd60cd98df59af97e84d24e49c8557331cfc26d301ce"
+checksum = "b94f61472cee1439c0b966b47e3aca9ae07e45d070759512cd390ea2bebc6675"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.1"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b6a852b24ab71dffc585bcb46eaf7959d175cb865a7152e35b348d1b2960422"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "core-foundation"
@@ -263,15 +261,15 @@ dependencies = [
 
 [[package]]
 name = "core-foundation-sys"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.12"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53fe5e26ff1b7aef8bca9c6080520cfb8d9333c7568e1829cef191a9723e5504"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
 ]
@@ -319,18 +317,18 @@ dependencies = [
 
 [[package]]
 name = "equivalent"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.10"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
+checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -347,9 +345,9 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "figment"
-version = "0.10.18"
+version = "0.10.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d032832d74006f99547004d49410a4b4218e4c33382d56ca3ff89df74f86b953"
+checksum = "8cb01cd46b0cf372153850f4c6c272d9cbea2da513e07538405148f95bd789f3"
 dependencies = [
  "atomic",
  "pear",
@@ -382,18 +380,18 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
 
 [[package]]
 name = "futures-channel"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -401,9 +399,9 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
 name = "futures-io"
@@ -413,9 +411,9 @@ checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -424,21 +422,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
 
 [[package]]
 name = "futures-task"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
 
 [[package]]
 name = "futures-util"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-core",
  "futures-io",
@@ -463,26 +461,38 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.11.1+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasi 0.14.3+wasi-0.2.4",
 ]
 
 [[package]]
 name = "gimli"
-version = "0.29.0"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ecd4077b5ae9fd2e9e169b102c6c330d0605168eb0e8bf79952b256dbefffd"
+checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "h2"
-version = "0.4.7"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccae279728d634d083c00f6099cb58f01cc99c145b84b8be2f6c74618d79922e"
+checksum = "f3c0b69cfcb4e1b9f1bf2f53f95f766e4661169728ec61cd3fe5a0166f2d1386"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -499,15 +509,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.14.5"
+version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-
-[[package]]
-name = "heck"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 
 [[package]]
 name = "heck"
@@ -517,9 +521,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.9"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hmac"
@@ -532,20 +536,20 @@ dependencies = [
 
 [[package]]
 name = "hostname"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9c7c7c8ac16c798734b8a24560c1362120597c40d5e1459f09498f8f6c8f2ba"
+checksum = "a56f203cd1c76362b69e3863fd987520ac36cf70a8c92627449b2f64a8cf7d65"
 dependencies = [
  "cfg-if",
  "libc",
- "windows",
+ "windows-link",
 ]
 
 [[package]]
 name = "http"
-version = "1.2.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f16ca2af56261c99fba8bac40a10251ce8188205a4c448fbb745a2e4daa76fea"
+checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
 dependencies = [
  "bytes",
  "fnv",
@@ -564,12 +568,12 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
- "futures-util",
+ "futures-core",
  "http",
  "http-body",
  "pin-project-lite",
@@ -577,15 +581,15 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.9.5"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d71d3574edd2771538b901e6549113b4006ece66150fb69c0fb6d9a2adae946"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
 name = "humantime"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+checksum = "9b112acc8b3adf4b107a8ec20977da0273a8c386765a3ec0229bd500a1443f9f"
 
 [[package]]
 name = "humantime-serde"
@@ -599,19 +603,21 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.5.2"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "256fb8d4bd6413123cc9d91832d78325c48ff41677595be797d90f42969beae0"
+checksum = "eb3aa54a13a0dfe7fbe3a59e0c76093041720fdc77b110cc0fc260fafb4dc51e"
 dependencies = [
+ "atomic-waker",
  "bytes",
  "futures-channel",
- "futures-util",
+ "futures-core",
  "h2",
  "http",
  "http-body",
  "httparse",
  "itoa",
  "pin-project-lite",
+ "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -619,11 +625,10 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.5"
+version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d191583f3da1305256f22463b9bb0471acad48a4e534a5218b9963e9c1f59b2"
+checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
- "futures-util",
  "http",
  "hyper",
  "hyper-util",
@@ -652,33 +657,41 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.10"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df2dcfbe0677734ab2f3ffa7fa7bfd4706bfdc1ef393f2ee30184aed67e631b4"
+checksum = "8d9b05277c7e8da2c93a568989bb6207bef0112e8d17df7a6eda4a3cf143bc5e"
 dependencies = [
+ "base64",
  "bytes",
  "futures-channel",
+ "futures-core",
  "futures-util",
  "http",
  "http-body",
  "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.0",
+ "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
+ "windows-registry",
 ]
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.60"
+version = "0.1.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7ffbb5a1b541ea2561f8c41c087286cc091e21e556a4f09a8f6cbf17b69b141"
+checksum = "b0c919e5debc312ad217002b8048a17b7d83f80703865bbfcfebb0458b0b27d8"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
  "iana-time-zone-haiku",
  "js-sys",
+ "log",
  "wasm-bindgen",
  "windows-core",
 ]
@@ -694,21 +707,22 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "1.5.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526"
+checksum = "200072f5d0e3614556f94a9930d5dc3e0662a652823904c3a75dc3b0af7fee47"
 dependencies = [
  "displaydoc",
+ "potential_utf",
  "yoke",
  "zerofrom",
  "zerovec",
 ]
 
 [[package]]
-name = "icu_locid"
-version = "1.5.0"
+name = "icu_locale_core"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637"
+checksum = "0cde2700ccaed3872079a65fb1a78f6c0a36c91570f28755dda67bc8f7d9f00a"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -718,30 +732,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "icu_locid_transform"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01d11ac35de8e40fdeda00d9e1e9d92525f3f9d887cdd7aa81d727596788b54e"
-dependencies = [
- "displaydoc",
- "icu_locid",
- "icu_locid_transform_data",
- "icu_provider",
- "tinystr",
- "zerovec",
-]
-
-[[package]]
-name = "icu_locid_transform_data"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdc8ff3388f852bede6b579ad4e978ab004f139284d7b28715f773507b946f6e"
-
-[[package]]
 name = "icu_normalizer"
-version = "1.5.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19ce3e0da2ec68599d193c93d088142efd7f9c5d6fc9b803774855747dc6a84f"
+checksum = "436880e8e18df4d7bbc06d58432329d6458cc84531f7ac5f024e93deadb37979"
 dependencies = [
  "displaydoc",
  "icu_collections",
@@ -749,72 +743,59 @@ dependencies = [
  "icu_properties",
  "icu_provider",
  "smallvec",
- "utf16_iter",
- "utf8_iter",
- "write16",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_normalizer_data"
-version = "1.5.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8cafbf7aa791e9b22bec55a167906f9e1215fd475cd22adfcf660e03e989516"
+checksum = "00210d6893afc98edb752b664b8890f0ef174c8adbb8d0be9710fa66fbbf72d3"
 
 [[package]]
 name = "icu_properties"
-version = "1.5.1"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93d6020766cfc6302c15dbbc9c8778c37e62c14427cb7f6e601d849e092aeef5"
+checksum = "016c619c1eeb94efb86809b015c58f479963de65bdb6253345c1a1276f22e32b"
 dependencies = [
  "displaydoc",
  "icu_collections",
- "icu_locid_transform",
+ "icu_locale_core",
  "icu_properties_data",
  "icu_provider",
- "tinystr",
+ "potential_utf",
+ "zerotrie",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_properties_data"
-version = "1.5.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67a8effbc3dd3e4ba1afa8ad918d5684b8868b3b26500753effea8d2eed19569"
+checksum = "298459143998310acd25ffe6810ed544932242d3f07083eee1084d83a71bd632"
 
 [[package]]
 name = "icu_provider"
-version = "1.5.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ed421c8a8ef78d3e2dbc98a973be2f3770cb42b606e3ab18d6237c4dfde68d9"
+checksum = "03c80da27b5f4187909049ee2d72f276f0d9f99a42c306bd0131ecfe04d8e5af"
 dependencies = [
  "displaydoc",
- "icu_locid",
- "icu_provider_macros",
+ "icu_locale_core",
  "stable_deref_trait",
  "tinystr",
  "writeable",
  "yoke",
  "zerofrom",
+ "zerotrie",
  "zerovec",
 ]
 
 [[package]]
-name = "icu_provider_macros"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "idna"
-version = "1.0.3"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
 dependencies = [
  "idna_adapter",
  "smallvec",
@@ -823,9 +804,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daca1df1c957320b2cf139ac61e7bd64fed304c5040df000a745aa1de3b4ef71"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -833,9 +814,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.2.6"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
+checksum = "f2481980430f9f78649238835720ddccc57e52df14ffce1c6f37391d61b563e9"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -848,66 +829,99 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8fae54786f62fb2918dcfae3d568594e50eb9b5c25bf04371af6fe7516452fb"
 
 [[package]]
-name = "ipnet"
-version = "2.10.1"
+name = "io-uring"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddc24109865250148c2e0f3d25d4f0f479571723792d3802153c60922a4fb708"
+checksum = "046fa2d4d00aea763528b4950358d0ead425372445dc8ff86312b3c69ff7727b"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
+name = "ipnet"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+
+[[package]]
+name = "iri-string"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc5ebe9c3a1a7a5127f920a418f7585e9e758e911d0466ed004f393b0e380b2"
+dependencies = [
+ "memchr",
+ "serde",
+]
 
 [[package]]
 name = "is-terminal"
-version = "0.4.12"
+version = "0.4.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f23ff5ef2b80d608d61efee834934d862cd92461afc0560dedf493e4c033738b"
+checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "is_terminal_polyfill"
-version = "1.70.0"
+version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8478577c03552c21db0e2724ffb8986a5ce7af88107e6be5d2ee6e158c12800"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itoa"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "js-sys"
-version = "0.3.69"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
+ "once_cell",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "libc"
-version = "0.2.154"
+version = "0.2.175"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae743338b92ff9146ce83992f766a31066a91a8c84a45e0e9f21e7cf6de6d346"
+checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
+
+[[package]]
+name = "libredox"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "391290121bad3d37fbddad76d8f5d1c1c314cfc646d143d7e07a3086ddff0ce3"
+dependencies = [
+ "bitflags",
+ "libc",
+ "redox_syscall",
+]
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.15"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "litemap"
-version = "0.7.4"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
+checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
 
 [[package]]
 name = "lock_api"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -915,9 +929,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.21"
+version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
+checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "md-5"
@@ -931,9 +945,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.2"
+version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
+checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
 
 [[package]]
 name = "memory-stats"
@@ -979,29 +993,29 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.7.4"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8a240ddb74feaf34a79a7add65a741f3167852fba007066dcac1ca548d89c08"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
- "adler",
+ "adler2",
 ]
 
 [[package]]
 name = "mio"
-version = "0.8.11"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
 dependencies = [
  "libc",
- "wasi",
- "windows-sys 0.48.0",
+ "wasi 0.11.1+wasi-snapshot-preview1",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "native-tls"
-version = "0.2.12"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8614eb2c83d59d1c8cc974dd3f920198647674a0a035e1af1fa58707e317466"
+checksum = "87de3442987e9dbec73158d5c715e7ad9072fda936bb03d19d7fa10e00520f0e"
 dependencies = [
  "libc",
  "log",
@@ -1035,26 +1049,32 @@ dependencies = [
 
 [[package]]
 name = "object"
-version = "0.36.1"
+version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "081b846d1d56ddfc18fdf1a922e4f6e07a11768ea1b92dec44e42b72712ccfce"
+checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "once_cell"
-version = "1.19.0"
+version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
 name = "openssl"
-version = "0.10.68"
+version = "0.10.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6174bc48f102d208783c2c84bf931bb75927a617866870de8a4ea85597f871f5"
+checksum = "8505734d46c8ab1e19a1dce3aef597ad87dcb4c37e7188231769bd6bd51cebf8"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -1076,15 +1096,15 @@ dependencies = [
 
 [[package]]
 name = "openssl-probe"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.104"
+version = "0.9.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45abf306cbf99debc8195b66b7346498d7b10c210de50418b5ccd7ceba08c741"
+checksum = "90096e2e47630d78b7d1c20952dc621f957103f8bc2c8359ec81290d75238571"
 dependencies = [
  "cc",
  "libc",
@@ -1094,9 +1114,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot"
-version = "0.12.3"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
+checksum = "70d58bf43669b5795d1576d0641cfb6fbb2057bf629506267a92807158584a13"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -1104,13 +1124,13 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
+checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.3",
+ "redox_syscall",
  "smallvec",
  "windows-targets 0.52.6",
 ]
@@ -1140,33 +1160,33 @@ dependencies = [
 
 [[package]]
 name = "percent-encoding"
-version = "2.3.1"
+version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "phf"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ade2d8b8f33c7333b51bcf0428d37e217e9f32192ae4772156f65063b8ce03dc"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
 dependencies = [
  "phf_shared",
 ]
 
 [[package]]
 name = "phf_shared"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90fcb95eef784c2ac79119d1dd819e162b5da872ce6f3c3abe1e8ca1c082f72b"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
 dependencies = [
  "siphasher",
 ]
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.14"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
 name = "pin-utils"
@@ -1176,15 +1196,15 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "postgres"
-version = "0.19.8"
+version = "0.19.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c9ec84ab55b0f9e418675de50052d494ba893fd28c65769a6e68fcdacbee2b8"
+checksum = "363e6dfbdd780d3aa3597b6eb430db76bb315fa9bad7fae595bb8def808b8470"
 dependencies = [
  "bytes",
  "fallible-iterator",
@@ -1196,11 +1216,11 @@ dependencies = [
 
 [[package]]
 name = "postgres-derive"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83145eba741b050ef981a9a1838c843fa7665e154383325aa8b440ae703180a2"
+checksum = "69700ea4603c5ef32d447708e6a19cd3e8ac197a000842e97f527daea5e4175f"
 dependencies = [
- "heck 0.4.1",
+ "heck",
  "proc-macro2",
  "quote",
  "syn",
@@ -1208,9 +1228,9 @@ dependencies = [
 
 [[package]]
 name = "postgres-protocol"
-version = "0.6.7"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acda0ebdebc28befa84bee35e651e4c5f09073d668c7aed4cf7e23c3cda84b23"
+checksum = "76ff0abab4a9b844b93ef7b81f1efc0a366062aaef2cd702c76256b5dc075c54"
 dependencies = [
  "base64",
  "byteorder",
@@ -1226,28 +1246,42 @@ dependencies = [
 
 [[package]]
 name = "postgres-types"
-version = "0.2.7"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02048d9e032fb3cc3413bbf7b83a15d84a5d419778e2628751896d856498eee9"
+checksum = "613283563cd90e1dfc3518d548caee47e0e725455ed619881f5cf21f36de4b48"
 dependencies = [
  "bytes",
  "chrono",
  "fallible-iterator",
  "postgres-derive",
  "postgres-protocol",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "potential_utf"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84df19adbe5b5a0782edcab45899906947ab039ccf4573713735ee7de1e6b08a"
+dependencies = [
+ "zerovec",
 ]
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.17"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.82"
+version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ad3d49ab951a01fbaafe34f2ec74122942fe18a3f9814c3268f1bb72042131b"
+checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
 dependencies = [
  "unicode-ident",
 ]
@@ -1267,29 +1301,34 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.36"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
-name = "rand"
-version = "0.8.5"
+name = "r-efi"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
- "libc",
  "rand_chacha",
  "rand_core",
 ]
 
 [[package]]
 name = "rand_chacha"
-version = "0.3.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
  "rand_core",
@@ -1297,36 +1336,27 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.6.4"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
- "getrandom",
+ "getrandom 0.3.3",
 ]
 
 [[package]]
 name = "redox_syscall"
-version = "0.4.1"
+version = "0.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
+checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
 dependencies = [
- "bitflags 1.3.2",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a908a6e00f1fdd0dfd9c0eb08ce85126f6d8bbda50017e74bc4a4b7d4a926a4"
-dependencies = [
- "bitflags 2.6.0",
+ "bitflags",
 ]
 
 [[package]]
 name = "reqwest"
-version = "0.12.12"
+version = "0.12.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43e734407157c3c2034e0258f5e4473ddb361b1e85f95a66690d67264d7cd1da"
+checksum = "d429f34c8092b2d42c7c93cec323bb4adeb7c67698f70839adec842ec10c7ceb"
 dependencies = [
  "base64",
  "bytes",
@@ -1342,70 +1372,66 @@ dependencies = [
  "hyper-rustls",
  "hyper-tls",
  "hyper-util",
- "ipnet",
  "js-sys",
  "log",
  "mime",
  "native-tls",
- "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls-pemfile",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
- "system-configuration",
  "tokio",
  "tokio-native-tls",
  "tower",
+ "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "windows-registry",
 ]
 
 [[package]]
 name = "ring"
-version = "0.17.8"
+version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom",
+ "getrandom 0.2.16",
  "libc",
- "spin",
  "untrusted",
  "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.24"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
+checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
 
 [[package]]
 name = "rustix"
-version = "0.38.34"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
+checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.23.21"
+version = "0.23.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f287924602bf649d949c63dc8ac8b235fa5387d394020705b80c4eb597ce5b8"
+checksum = "c0ebcbd2f03de0fc1122ad9bb24b127a5a6cd51d72604a3f3c50ac459762b6cc"
 dependencies = [
  "once_cell",
  "rustls-pki-types",
@@ -1415,25 +1441,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustls-pemfile"
-version = "2.2.0"
+name = "rustls-pki-types"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+checksum = "229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79"
 dependencies = [
- "rustls-pki-types",
+ "zeroize",
 ]
 
 [[package]]
-name = "rustls-pki-types"
-version = "1.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2bf47e6ff922db3825eb750c4e2ff784c6ff8fb9e13046ef6a1d1c5401b0b37"
-
-[[package]]
 name = "rustls-webpki"
-version = "0.102.8"
+version = "0.103.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
+checksum = "0a17884ae0c1b773f1ccd2bd4a8c72f16da897310a98b0e84bf349ad5ead92fc"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -1441,10 +1461,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "ryu"
-version = "1.0.18"
+name = "rustversion"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "ryu"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "schannel"
@@ -1467,7 +1493,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -1486,18 +1512,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.201"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "780f1cebed1629e4753a1a38a3c72d30b97ec044f0aef68cb26650a3c5cf363c"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.201"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5e405930b9796f1c00bee880d03fc7e0bb4b9a11afc776885ffe84320da2865"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1506,9 +1532,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.135"
+version = "1.0.143"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b0d7ba2887406110130a978386c4e1befb98c674b4fba677954e4db976630d9"
+checksum = "d401abef1d108fbd9cbaebc3e46611f4b1021f714a0597a71f41ee463f5f4a5a"
 dependencies = [
  "itoa",
  "memchr",
@@ -1518,9 +1544,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.5"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb3622f419d1296904700073ea6cc23ad690adbd66f13ea683df73298736f0c1"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
 dependencies = [
  "serde",
 ]
@@ -1539,9 +1565,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.8"
+version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -1549,41 +1575,48 @@ dependencies = [
 ]
 
 [[package]]
-name = "siphasher"
-version = "0.3.11"
+name = "shlex"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "siphasher"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
 name = "slab"
-version = "0.4.9"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
-dependencies = [
- "autocfg",
-]
+checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
 name = "smallvec"
-version = "1.13.2"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
-version = "0.5.7"
+version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce305eb0b4296696835b71df73eb912e0f1ffd2556a501fcede6e0c50349191c"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
 ]
 
 [[package]]
-name = "spin"
-version = "0.9.8"
+name = "socket2"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "stable_deref_trait"
@@ -1629,9 +1662,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.62"
+version = "2.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f660c3bfcefb88c538776b6685a0c472e3128b51e74d48793dc2a488196e8eb"
+checksum = "ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1649,9 +1682,9 @@ dependencies = [
 
 [[package]]
 name = "synstructure"
-version = "0.13.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1664,7 +1697,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
- "bitflags 2.6.0",
+ "bitflags",
  "core-foundation",
  "system-configuration-sys",
 ]
@@ -1681,15 +1714,15 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.12.0"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04cbcdd0c794ebb0d4cf35e88edd2f7d2c4c3e9a5a6dab322839b321c6a87a64"
+checksum = "15b61f8f20e3a6f7e0649d825294eaf317edce30f82cf6026e7e4cb9222a7d1e"
 dependencies = [
- "cfg-if",
  "fastrand",
+ "getrandom 0.3.3",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1703,19 +1736,18 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.1.8"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
- "once_cell",
 ]
 
 [[package]]
 name = "tinystr"
-version = "0.7.6"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
+checksum = "5d4f6d1145dcb577acf783d4e601bc1d76a13337bb54e6233add580b07344c8b"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -1723,9 +1755,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.8.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "445e881f4f6d382d5f27c034e25eb92edd7c784ceab92a0937db7f2e9471b938"
+checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -1738,17 +1770,19 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.38.1"
+version = "1.47.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb2caba9f80616f438e09748d5acda951967e1ea58508ef53d9c6402485a46df"
+checksum = "89e49afdadebb872d3145a5638b59eb0691ea23e46ca484037cfab3b76b95038"
 dependencies = [
  "backtrace",
  "bytes",
+ "io-uring",
  "libc",
  "mio",
  "pin-project-lite",
- "socket2",
- "windows-sys 0.48.0",
+ "slab",
+ "socket2 0.6.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1763,9 +1797,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-postgres"
-version = "0.7.11"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03adcf0147e203b6032c0b2d30be1415ba03bc348901f3ff1cc0df6a733e60c3"
+checksum = "6c95d533c83082bb6490e0189acaa0bbeef9084e60471b696ca6988cd0541fb0"
 dependencies = [
  "async-trait",
  "byteorder",
@@ -1781,7 +1815,7 @@ dependencies = [
  "postgres-protocol",
  "postgres-types",
  "rand",
- "socket2",
+ "socket2 0.5.10",
  "tokio",
  "tokio-util",
  "whoami",
@@ -1789,9 +1823,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.26.1"
+version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6d0975eaace0cf0fcadee4e4aaa5da15b5c079146f2cffb67c113be122bf37"
+checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
 dependencies = [
  "rustls",
  "tokio",
@@ -1799,9 +1833,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.11"
+version = "0.7.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cf6b47b3771c49ac75ad09a6162f53ad4b8088b76ac60e8ec1455b31a189fe1"
+checksum = "14307c986784f72ef81c89db7d9e28d6ac26d16213b109ea501696195e6e3ce5"
 dependencies = [
  "bytes",
  "futures-core",
@@ -1812,9 +1846,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.12"
+version = "0.8.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9dd1545e8208b4a5af1aa9bbd0b4cf7e9ea08fabc5d0a5c67fcaafa17433aa3"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -1824,25 +1858,32 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.5"
+version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.22.12"
+version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3328d4f68a705b2a4498da1d580585d39a6510f98318a2cec3018a7ec61ddef"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
  "indexmap",
  "serde",
  "serde_spanned",
  "toml_datetime",
+ "toml_write",
  "winnow",
 ]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tower"
@@ -1855,6 +1896,24 @@ dependencies = [
  "pin-project-lite",
  "sync_wrapper",
  "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "iri-string",
+ "pin-project-lite",
+ "tower",
  "tower-layer",
  "tower-service",
 ]
@@ -1883,9 +1942,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.33"
+version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
+checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
 dependencies = [
  "once_cell",
 ]
@@ -1898,9 +1957,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typenum"
-version = "1.17.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
 
 [[package]]
 name = "uncased"
@@ -1913,30 +1972,30 @@ dependencies = [
 
 [[package]]
 name = "unicode-bidi"
-version = "0.3.15"
+version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.12"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.23"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a56d1686db2308d901306f92a263857ef59ea39678a5458e7cb17f01415101f5"
+checksum = "5033c97c4262335cded6d6fc3e5c18ab755e1a3dc96376350f3d8e9f009ad956"
 dependencies = [
  "tinyvec",
 ]
 
 [[package]]
 name = "unicode-properties"
-version = "0.1.1"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4259d9d4425d9f0661581b804cb85fe66a4c631cadd8f490d1c13a35d5d9291"
+checksum = "e70f2a8b45122e719eb623c01822704c4e0907e7e426a05927e1a1cfff5b75d0"
 
 [[package]]
 name = "untrusted"
@@ -1946,20 +2005,15 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
-version = "2.5.4"
+version = "2.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
+checksum = "08bc136a29a3d1758e07a9cca267be308aeebf5cfd5a10f3f67ab2097683ef5b"
 dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
+ "serde",
 ]
-
-[[package]]
-name = "utf16_iter"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
 
 [[package]]
 name = "utf8_iter"
@@ -1969,9 +2023,9 @@ checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utf8parse"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "vcpkg"
@@ -1981,9 +2035,9 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "want"
@@ -1996,9 +2050,18 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
+version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+
+[[package]]
+name = "wasi"
+version = "0.14.3+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a51ae83037bdd272a9e28ce236db8c07016dd0d50c27038b3f407533c030c95"
+dependencies = [
+ "wit-bindgen",
+]
 
 [[package]]
 name = "wasite"
@@ -2008,23 +2071,24 @@ checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.92"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
 dependencies = [
  "cfg-if",
+ "once_cell",
+ "rustversion",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.92"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
 dependencies = [
  "bumpalo",
  "log",
- "once_cell",
  "proc-macro2",
  "quote",
  "syn",
@@ -2033,21 +2097,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.42"
+version = "0.4.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76bc14366121efc8dbb487ab05bcc9d346b3b5ec0eaa76e46594cabbe51762c0"
+checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
 dependencies = [
  "cfg-if",
  "js-sys",
+ "once_cell",
  "wasm-bindgen",
  "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.92"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2055,9 +2120,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.92"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2068,15 +2133,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.92"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+dependencies = [
+ "unicode-ident",
+]
 
 [[package]]
 name = "web-sys"
-version = "0.3.69"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef"
+checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2084,80 +2152,92 @@ dependencies = [
 
 [[package]]
 name = "whoami"
-version = "1.5.1"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a44ab49fad634e88f55bf8f9bb3abd2f27d7204172a112c7c9987e01c1c94ea9"
+checksum = "5d4a4db5077702ca3015d3d02d74974948aba2ad9e12ab7df718ee64ccd7e97d"
 dependencies = [
- "redox_syscall 0.4.1",
+ "libredox",
  "wasite",
  "web-sys",
 ]
 
 [[package]]
 name = "winapi-util"
-version = "0.1.8"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d4cc384e1e73b93bafa6fb4f1df8c41695c8a91cf9c4c64358067d15a7b6c6b"
+checksum = "0978bf7171b3d90bac376700cb56d606feb40f251a475a5d6634613564460b22"
 dependencies = [
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "windows"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e48a53791691ab099e5e2ad123536d0fff50652600abaf43bbf952894110d0be"
-dependencies = [
- "windows-core",
- "windows-targets 0.52.6",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "windows-core"
-version = "0.52.0"
+version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-implement",
+ "windows-interface",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
 ]
 
 [[package]]
-name = "windows-registry"
-version = "0.2.0"
+name = "windows-implement"
+version = "0.60.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0"
+checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
 dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
+name = "windows-registry"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e"
+dependencies = [
+ "windows-link",
  "windows-result",
  "windows-strings",
- "windows-targets 0.52.6",
 ]
 
 [[package]]
 name = "windows-result"
-version = "0.2.0"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-link",
 ]
 
 [[package]]
 name = "windows-strings"
-version = "0.1.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
- "windows-result",
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
+ "windows-link",
 ]
 
 [[package]]
@@ -2179,18 +2259,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows-targets"
-version = "0.48.5"
+name = "windows-sys"
+version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
+ "windows-targets 0.53.3",
 ]
 
 [[package]]
@@ -2202,7 +2276,7 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
@@ -2210,10 +2284,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.48.5"
+name = "windows-targets"
+version = "0.53.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+checksum = "d5fe6031c4041849d7c496a8ded650796e7b6ecc19df1a431c1a363342e5dc91"
+dependencies = [
+ "windows-link",
+ "windows_aarch64_gnullvm 0.53.0",
+ "windows_aarch64_msvc 0.53.0",
+ "windows_i686_gnu 0.53.0",
+ "windows_i686_gnullvm 0.53.0",
+ "windows_i686_msvc 0.53.0",
+ "windows_x86_64_gnu 0.53.0",
+ "windows_x86_64_gnullvm 0.53.0",
+ "windows_x86_64_msvc 0.53.0",
+]
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -2222,10 +2307,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_msvc"
-version = "0.48.5"
+name = "windows_aarch64_gnullvm"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -2234,10 +2319,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
+name = "windows_aarch64_msvc"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
+checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2246,16 +2331,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.48.5"
+name = "windows_i686_gnullvm"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -2264,10 +2355,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
+name = "windows_i686_msvc"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
+checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -2276,10 +2367,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.48.5"
+name = "windows_x86_64_gnu"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -2288,10 +2379,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.5"
+name = "windows_x86_64_gnullvm"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
+checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -2300,25 +2391,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
-name = "winnow"
-version = "0.6.8"
+name = "windows_x86_64_msvc"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3c52e9c97a68071b23e836c9380edae937f17b9c4667bd021973efc689f618d"
+checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
+
+[[package]]
+name = "winnow"
+version = "0.7.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
-name = "write16"
-version = "1.0.0"
+name = "wit-bindgen"
+version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
+checksum = "052283831dbae3d879dc7f51f3d92703a316ca49f91540417d38591826127814"
 
 [[package]]
 name = "writeable"
-version = "0.5.5"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
+checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
 
 [[package]]
 name = "yansi"
@@ -2328,9 +2425,9 @@ checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yoke"
-version = "0.7.5"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40"
+checksum = "5f41bb01b8226ef4bfd589436a297c53d118f65921786300e427be8d487695cc"
 dependencies = [
  "serde",
  "stable_deref_trait",
@@ -2340,9 +2437,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.7.5"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
+checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2351,19 +2448,39 @@ dependencies = [
 ]
 
 [[package]]
-name = "zerofrom"
-version = "0.1.5"
+name = "zerocopy"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cff3ee08c995dee1859d998dea82f7374f2826091dd9cd47def953cae446cd2e"
+checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2378,10 +2495,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
 
 [[package]]
-name = "zerovec"
-version = "0.10.4"
+name = "zerotrie"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa2b893d79df23bfb12d5461018d408ea19dfafe76c2c7ef6d4eba614f8ff079"
+checksum = "36f0bbd478583f79edad978b407914f61b2972f5af6fa089686016be8f9af595"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7aa2bd55086f1ab526693ecbe444205da57e25f4489879da80635a46d90e73b"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -2390,9 +2518,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.10.3"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
+checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ log = "0.4.21"
 stderrlog = "0.6.0"
 clap = { version = "4.5.4", features = ["derive"] }
 postgres = { version = "0.19.8", features = ["with-chrono-0_4"] }
-postgres-types = { version = "0.2.7", features = ["derive"] }
+postgres-types = { version = "0.2.7", features = ["derive", "with-serde_json-1"] }
 hostname = "0.4.0"
 reqwest = { version = "0.12.9", features = ["blocking", "json"] }
 serde_json = "1.0.135"

--- a/README.md
+++ b/README.md
@@ -21,7 +21,11 @@ Also, I do plan to keep this as simple as possible because I like Linux philosop
 
 Protocol is simple text based protocol. Metrics are in form of `name|type|value` and optionally some additional fields separated by `|` depending on metric type.
 
-Metric name is any valid UTF-8 sequence of at least one byte. It's backends job to sanitize name if needed. Pipe character and backslash can be escaped using backslash.
+Metric name is any valid UTF-8 sequence of at least one byte. It's backends job to sanitize name if needed. Special characters in `name` part are `|`, `;` and `\` and if used, must be escaped using `\`.
+
+Each metric can have associated tags that are used to fine tune aggregations. Tags are a part of `name` in format `name=value` separated by `;` without a trailing `;`. If `=` or `\` is used as a part of tag name, it must be escaped using `\`. If `;`, `\` or `|` is used as a part of tag value, it must be escaped using `\`.
+
+Assigning two tags to a metric would look like `name;tag1=value1;tag2=value2`.
 
 Type can be any of `c`, `t` or `g`.
 

--- a/src/backend/console.rs
+++ b/src/backend/console.rs
@@ -7,48 +7,46 @@ pub struct Console {}
 
 impl Backend for Console {
     fn publish(&mut self, time: &DateTime<Utc>, time_frame: &TimeFrame, logger: Logger) {
-        logger.info(&format!(
-            "{} - host: {}",
-            time.to_rfc3339(),
-            time_frame.host()
-        ));
+        logger.info(time.to_rfc3339().as_str());
 
         if !time_frame.gauges().is_empty() {
             logger.info("Gauges:");
 
-            time_frame
-                .gauges()
-                .iter()
-                .for_each(|(name, value)| logger.info(&format!("  {name} - {value}")));
+            time_frame.gauges().iter().for_each(|(identifier, value)| {
+                logger.info(&format!("  {} - {value}", identifier.name()))
+            });
         }
 
         if !time_frame.counters().is_empty() {
             logger.info("Counters:");
 
-            time_frame.counters().iter().for_each(|(name, stats)| {
-                logger.info(&format!("  {name}"));
-                logger.info(&format!("    count: {}", stats.count()));
-                logger.info(&format!("    sum: {}", stats.sum()));
-                logger.info(&format!("    std: {}", stats.std()));
-                logger.info(&format!("    median: {}", stats.median()));
-                logger.info(&format!("    p75: {}", stats.percentile(0.75)));
-                logger.info(&format!("    p90: {}", stats.percentile(0.90)));
+            time_frame
+                .counters()
+                .iter()
+                .for_each(|(identifier, stats)| {
+                    logger.info(&format!("  {}", identifier.name()));
+                    logger.info(&format!("    count: {}", stats.count()));
+                    logger.info(&format!("    sum: {}", stats.sum()));
+                    logger.info(&format!("    std: {}", stats.std()));
+                    logger.info(&format!("    median: {}", stats.median()));
+                    logger.info(&format!("    p75: {}", stats.percentile(0.75)));
+                    logger.info(&format!("    p90: {}", stats.percentile(0.90)));
 
-                if let Some(min) = stats.min() {
-                    logger.info(&format!("    min: {min}"));
-                }
+                    if let Some(min) = stats.min() {
+                        logger.info(&format!("    min: {min}"));
+                    }
 
-                if let Some(max) = stats.max() {
-                    logger.info(&format!("    max: {max}"));
-                }
-            });
+                    if let Some(max) = stats.max() {
+                        logger.info(&format!("    max: {max}"));
+                    }
+                });
         }
 
         if !time_frame.timings().is_empty() {
             logger.info("Timings:");
 
-            time_frame.timings().iter().for_each(|(name, stats)| {
-                logger.info(&format!("  {name}"));
+            time_frame.timings().iter().for_each(|(identifier, stats)| {
+                logger.info(&format!("  {}", identifier.name()));
                 logger.info(&format!("    count: {}", stats.count()));
                 logger.info(&format!("    sum: {}", stats.sum()));
                 logger.info(&format!("    std: {}", stats.std()));

--- a/src/backend/elastic.rs
+++ b/src/backend/elastic.rs
@@ -2,7 +2,7 @@ use crate::backend::{Backend, Logger};
 use crate::metrics::TimeFrame;
 use chrono::{DateTime, Utc};
 use reqwest::blocking::Client;
-use serde_json::Value;
+use serde_json::{Map, Value};
 use std::collections::HashMap;
 use std::fmt::{Debug, Formatter};
 
@@ -30,8 +30,8 @@ impl ElasticSearch {
     fn insert(
         &mut self,
         time: &DateTime<Utc>,
-        host: &str,
         mut map: HashMap<String, Value>,
+        tags: &HashMap<String, String>,
         logger: &Logger,
     ) {
         let index = self
@@ -39,8 +39,14 @@ impl ElasticSearch {
             .clone()
             .replace("{date}", &time.format("%Y-%m-%d").to_string());
 
-        map.insert("host".into(), host.into());
         map.insert("timestamp".into(), time.to_rfc3339().into());
+        map.insert(
+            "tags".into(),
+            tags.iter()
+                .map(|(k, v)| (k.clone(), Value::String(v.clone())))
+                .collect::<Map<String, Value>>()
+                .into(),
+        );
 
         let err = match self
             .client
@@ -61,41 +67,55 @@ impl ElasticSearch {
 
 impl Backend for ElasticSearch {
     fn publish(&mut self, time: &DateTime<Utc>, time_frame: &TimeFrame, logger: Logger) {
-        time_frame.gauges().iter().for_each(|(name, value)| {
+        time_frame.gauges().iter().for_each(|(identifier, value)| {
             self.insert(
                 time,
-                time_frame.host(),
-                HashMap::from([(format!("gauge.{name}"), (*value).into())]),
+                HashMap::from([(format!("gauge.{}", identifier.name()), (*value).into())]),
+                identifier.tags(),
                 &logger,
             );
 
-            logger.debug(&format!("Processed gauge {name}"));
+            logger.debug(&format!(
+                "Processed gauge {} with tags {:?}",
+                identifier.name(),
+                identifier.tags()
+            ));
         });
 
-        time_frame.counters().iter().for_each(|(name, stats)| {
-            let mut map = HashMap::from([
-                (format!("counter.{name}.count"), stats.count().into()),
-                (format!("counter.{name}.sum"), stats.sum().into()),
-                (format!("counter.{name}.std"), stats.std().into()),
-                (format!("counter.{name}.median"), stats.median().into()),
-                (format!("counter.{name}.p75"), stats.percentile(0.75).into()),
-                (format!("counter.{name}.p90"), stats.percentile(0.90).into()),
-            ]);
+        time_frame
+            .counters()
+            .iter()
+            .for_each(|(identifier, stats)| {
+                let name = identifier.name();
 
-            if let Some(min) = stats.min() {
-                map.insert(format!("counter.{name}.min"), min.into());
-            }
+                let mut map = HashMap::from([
+                    (format!("counter.{name}.count"), stats.count().into()),
+                    (format!("counter.{name}.sum"), stats.sum().into()),
+                    (format!("counter.{name}.std"), stats.std().into()),
+                    (format!("counter.{name}.median"), stats.median().into()),
+                    (format!("counter.{name}.p75"), stats.percentile(0.75).into()),
+                    (format!("counter.{name}.p90"), stats.percentile(0.90).into()),
+                ]);
 
-            if let Some(max) = stats.max() {
-                map.insert(format!("counter.{name}.max"), max.into());
-            }
+                if let Some(min) = stats.min() {
+                    map.insert(format!("counter.{name}.min"), min.into());
+                }
 
-            self.insert(time, time_frame.host(), map, &logger);
+                if let Some(max) = stats.max() {
+                    map.insert(format!("counter.{name}.max"), max.into());
+                }
 
-            logger.debug(&format!("Processed counter {name}"));
-        });
+                self.insert(time, map, identifier.tags(), &logger);
 
-        time_frame.timings().iter().for_each(|(name, stats)| {
+                logger.debug(&format!(
+                    "Processed counter {name} with tags {:?}",
+                    identifier.tags()
+                ));
+            });
+
+        time_frame.timings().iter().for_each(|(identifier, stats)| {
+            let name = identifier.name();
+
             let mut map = HashMap::from([
                 (format!("timing.{name}.count"), stats.count().into()),
                 (format!("timing.{name}.sum"), stats.sum().into()),
@@ -113,9 +133,12 @@ impl Backend for ElasticSearch {
                 map.insert(format!("timing.{name}.max"), max.into());
             }
 
-            self.insert(time, time_frame.host(), map, &logger);
+            self.insert(time, map, identifier.tags(), &logger);
 
-            logger.debug(&format!("Processed timing {name}"));
+            logger.debug(&format!(
+                "Processed timing {name} with tags {:?}",
+                identifier.tags()
+            ));
         });
     }
 }

--- a/src/backend/postgresql.rs
+++ b/src/backend/postgresql.rs
@@ -1,82 +1,102 @@
 use crate::backend::{Backend, Logger};
 use crate::metrics::TimeFrame;
 use chrono::{DateTime, Utc};
+use postgres_types::Json;
+use std::collections::HashMap;
 use std::fmt::{Debug, Formatter};
-
 /*
 Used table structure is bellow.
+
+create extension btree_gin;
 
 create table metric_counters
 (
     name  text        not null,
     time  timestamptz not null,
-    host  text        not null,
-    value float8,
-    primary key (name, time, host)
+    value float8      not null,
+    tags  jsonb       not null
 );
+
+create index index_metric_counters on metric_counters (name, time desc);
+create index index_metric_counters_tags on metric_counters using gin (name, tags, time);
 
 create table metric_timers
 (
     name  text        not null,
     time  timestamptz not null,
-    host  text        not null,
-    value float8,
-    primary key (name, time, host)
+    value float8      not null,
+    tags  jsonb       not null
 );
+
+create index index_metric_timers on metric_timers (name, time desc);
+create index index_metric_timers_tags on metric_timers using gin (name, tags, time);
 
 create table metric_gauges
 (
     name  text        not null,
     time  timestamptz not null,
-    host  text        not null,
-    value float8,
-    primary key (name, time, host)
+    value float8      not null,
+    tags  jsonb       not null
 );
+
+create index index_metric_gauges on metric_gauges (name, time desc);
+create index index_metric_gauges_tags on metric_gauges using gin (name, tags, time);
 
 It's also possible to use https://github.com/timescale/timescaledb and
 slightly modify create commands above to use hyper-tables.
 
+create extension btree_gin;
+
 create table metric_counters
 (
     name  text        not null,
     time  timestamptz not null,
-    host  text        not null,
-    value float8,
-    primary key (name, time, host)
+    value float8      not null,
+    tags  jsonb       not null
 )
-with (
-  timescaledb.hypertable,
-  timescaledb.partition_column='time',
-  timescaledb.segmentby='name'
-);
+    with (
+        timescaledb.hypertable,
+        timescaledb.partition_column = 'time',
+        timescaledb.segmentby = 'name',
+        timescaledb.create_default_indexes = false
+        );
+
+create index index_metric_counters on metric_counters (name, time desc);
+create index index_metric_counters_tags on metric_counters using gin (name, tags, time);
 
 create table metric_timers
 (
     name  text        not null,
     time  timestamptz not null,
-    host  text        not null,
-    value float8,
-    primary key (name, time, host)
+    value float8      not null,
+    tags  jsonb       not null
 )
-with (
-  timescaledb.hypertable,
-  timescaledb.partition_column='time',
-  timescaledb.segmentby='name'
-);
+    with (
+        timescaledb.hypertable,
+        timescaledb.partition_column = 'time',
+        timescaledb.segmentby = 'name',
+        timescaledb.create_default_indexes = false
+        );
+
+create index index_metric_timers on metric_timers (name, time desc);
+create index index_metric_timers_tags on metric_timers using gin (name, tags, time);
 
 create table metric_gauges
 (
     name  text        not null,
     time  timestamptz not null,
-    host  text        not null,
-    value float8,
-    primary key (name, time, host)
+    value float8      not null,
+    tags  jsonb       not null
 )
-with (
-  timescaledb.hypertable,
-  timescaledb.partition_column='time',
-  timescaledb.segmentby='name'
-);
+    with (
+        timescaledb.hypertable,
+        timescaledb.partition_column = 'time',
+        timescaledb.segmentby = 'name',
+        timescaledb.create_default_indexes = false
+        );
+
+create index index_metric_gauges on metric_gauges (name, time desc);
+create index index_metric_gauges_tags on metric_gauges using gin (name, tags, time);
  */
 
 pub struct PostgreSQL {
@@ -104,9 +124,9 @@ impl PostgreSQL {
     fn insert(
         &mut self,
         time: &DateTime<Utc>,
-        host: &str,
         metric_kind: MetricKind,
         name: &str,
+        tags: &HashMap<String, String>,
         value: f64,
         logger: &Logger,
     ) {
@@ -118,14 +138,15 @@ impl PostgreSQL {
 
         let sql = format!(
             r"
-insert into {table_name} (name, time, host, value)
+insert into {table_name} (name, time, value, tags)
 values ($1, $2, $3, $4)
-on conflict (name, time, host)
-    do nothing
 "
         );
 
-        if let Err(err) = self.client.execute(&sql, &[&name, time, &host, &value]) {
+        if let Err(err) = self
+            .client
+            .execute(&sql, &[&name, time, &value, &Json::<_>(tags)])
+        {
             logger.error(&format!("Insert record failed: {err}"));
         }
     }
@@ -133,65 +154,153 @@ on conflict (name, time, host)
 
 impl Backend for PostgreSQL {
     fn publish(&mut self, time: &DateTime<Utc>, time_frame: &TimeFrame, logger: Logger) {
-        time_frame.gauges().iter().for_each(|(name, value)| {
+        time_frame.gauges().iter().for_each(|(identifier, value)| {
             self.insert(
                 time,
-                time_frame.host(),
                 MetricKind::Gauge,
-                name,
+                identifier.name(),
+                identifier.tags(),
                 *value as f64,
                 &logger,
             );
 
-            logger.debug(&format!("Processed gauge {name}"));
+            logger.debug(&format!(
+                "Processed gauge {} with tags {:?}",
+                identifier.name(),
+                identifier.tags()
+            ));
         });
 
-        time_frame.counters().iter().for_each(|(name, stats)| {
+        time_frame
+            .counters()
+            .iter()
+            .for_each(|(identifier, stats)| {
+                let name = identifier.name();
+                let tags = identifier.tags();
+
+                self.insert(
+                    time,
+                    MetricKind::Counter,
+                    &format!("{name}.count"),
+                    tags,
+                    stats.count() as f64,
+                    &logger,
+                );
+                self.insert(
+                    time,
+                    MetricKind::Counter,
+                    &format!("{name}.sum"),
+                    tags,
+                    stats.sum() as f64,
+                    &logger,
+                );
+                self.insert(
+                    time,
+                    MetricKind::Counter,
+                    &format!("{name}.std"),
+                    tags,
+                    stats.std(),
+                    &logger,
+                );
+                self.insert(
+                    time,
+                    MetricKind::Counter,
+                    &format!("{name}.median"),
+                    tags,
+                    stats.median(),
+                    &logger,
+                );
+                self.insert(
+                    time,
+                    MetricKind::Counter,
+                    &format!("{name}.p75"),
+                    tags,
+                    stats.percentile(0.75) as f64,
+                    &logger,
+                );
+                self.insert(
+                    time,
+                    MetricKind::Counter,
+                    &format!("{name}.p90"),
+                    tags,
+                    stats.percentile(0.90) as f64,
+                    &logger,
+                );
+
+                if let Some(min) = stats.min() {
+                    self.insert(
+                        time,
+                        MetricKind::Counter,
+                        &format!("{name}.min"),
+                        tags,
+                        min as f64,
+                        &logger,
+                    );
+                }
+
+                if let Some(max) = stats.max() {
+                    self.insert(
+                        time,
+                        MetricKind::Counter,
+                        &format!("{name}.max"),
+                        tags,
+                        max as f64,
+                        &logger,
+                    );
+                }
+
+                logger.debug(&format!("Processed counter {name} with tags {tags:?}"));
+            });
+
+        time_frame.timings().iter().for_each(|(identifier, stats)| {
+            let name = identifier.name();
+            let tags = identifier.tags();
+
             self.insert(
                 time,
-                time_frame.host(),
-                MetricKind::Counter,
+                MetricKind::Timer,
                 &format!("{name}.count"),
+                tags,
                 stats.count() as f64,
                 &logger,
             );
             self.insert(
                 time,
-                time_frame.host(),
-                MetricKind::Counter,
+                MetricKind::Timer,
                 &format!("{name}.sum"),
+                tags,
                 stats.sum() as f64,
                 &logger,
             );
             self.insert(
                 time,
-                time_frame.host(),
-                MetricKind::Counter,
+                MetricKind::Timer,
                 &format!("{name}.std"),
+                tags,
                 stats.std(),
                 &logger,
             );
             self.insert(
                 time,
-                time_frame.host(),
-                MetricKind::Counter,
+                MetricKind::Timer,
                 &format!("{name}.median"),
+                tags,
                 stats.median(),
                 &logger,
             );
             self.insert(
                 time,
-                time_frame.host(),
-                MetricKind::Counter,
+                MetricKind::Timer,
                 &format!("{name}.p75"),
+                tags,
                 stats.percentile(0.75) as f64,
                 &logger,
             );
             self.insert(
                 time,
-                time_frame.host(),
-                MetricKind::Counter,
+                MetricKind::Timer,
                 &format!("{name}.p90"),
+                tags,
                 stats.percentile(0.90) as f64,
                 &logger,
             );
@@ -199,9 +308,9 @@ impl Backend for PostgreSQL {
             if let Some(min) = stats.min() {
                 self.insert(
                     time,
-                    time_frame.host(),
-                    MetricKind::Counter,
+                    MetricKind::Timer,
                     &format!("{name}.min"),
+                    tags,
                     min as f64,
                     &logger,
                 );
@@ -210,90 +319,15 @@ impl Backend for PostgreSQL {
             if let Some(max) = stats.max() {
                 self.insert(
                     time,
-                    time_frame.host(),
-                    MetricKind::Counter,
+                    MetricKind::Timer,
                     &format!("{name}.max"),
+                    tags,
                     max as f64,
                     &logger,
                 );
             }
 
-            logger.debug(&format!("Processed counter {name}"));
-        });
-
-        time_frame.timings().iter().for_each(|(name, stats)| {
-            self.insert(
-                time,
-                time_frame.host(),
-                MetricKind::Timer,
-                &format!("{name}.count"),
-                stats.count() as f64,
-                &logger,
-            );
-            self.insert(
-                time,
-                time_frame.host(),
-                MetricKind::Timer,
-                &format!("{name}.sum"),
-                stats.sum() as f64,
-                &logger,
-            );
-            self.insert(
-                time,
-                time_frame.host(),
-                MetricKind::Timer,
-                &format!("{name}.std"),
-                stats.std(),
-                &logger,
-            );
-            self.insert(
-                time,
-                time_frame.host(),
-                MetricKind::Timer,
-                &format!("{name}.median"),
-                stats.median(),
-                &logger,
-            );
-            self.insert(
-                time,
-                time_frame.host(),
-                MetricKind::Timer,
-                &format!("{name}.p75"),
-                stats.percentile(0.75) as f64,
-                &logger,
-            );
-            self.insert(
-                time,
-                time_frame.host(),
-                MetricKind::Timer,
-                &format!("{name}.p90"),
-                stats.percentile(0.90) as f64,
-                &logger,
-            );
-
-            if let Some(min) = stats.min() {
-                self.insert(
-                    time,
-                    time_frame.host(),
-                    MetricKind::Timer,
-                    &format!("{name}.min"),
-                    min as f64,
-                    &logger,
-                );
-            }
-
-            if let Some(max) = stats.max() {
-                self.insert(
-                    time,
-                    time_frame.host(),
-                    MetricKind::Timer,
-                    &format!("{name}.max"),
-                    max as f64,
-                    &logger,
-                );
-            }
-
-            logger.debug(&format!("Processed timing {name}"));
+            logger.debug(&format!("Processed timing {name} with tags {tags:?}"));
         });
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,7 @@ use figment::Figment;
 use serde::Deserialize;
 use stderrlog::Timestamp;
 
-use crate::metrics::{GaugeOperation, Metric, MetricKind, Registry, TimerResolution};
+use crate::metrics::{GaugeOperation, Identifier, Metric, MetricKind, Registry, TimerResolution};
 
 mod backend;
 mod metrics;
@@ -148,7 +148,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         let new_telemetry = telemetry.new_with_gauges();
 
         telemetry.add(Metric::new(
-            "metco.memory_usage".into(),
+            Identifier::without_tags("metco.memory_usage".into()),
             MetricKind::Gauge(GaugeOperation::Set(
                 memory_stats::memory_stats()
                     .expect("Memory usage should be computed")
@@ -281,7 +281,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                 let now = Instant::now();
 
                 telemetry.add(Metric::new(
-                    "metco.bytes_read".into(),
+                    Identifier::without_tags("metco.bytes_read".into()),
                     MetricKind::Counter(size_read as u64),
                 ));
 
@@ -319,21 +319,21 @@ fn main() -> Result<(), Box<dyn Error>> {
 
                 if counters_count > 0 {
                     telemetry.add(Metric::new(
-                        "metco.counters_parsed".into(),
+                        Identifier::without_tags("metco.counters_parsed".into()),
                         MetricKind::Counter(counters_count),
                     ));
                 }
 
                 if timers_count > 0 {
                     telemetry.add(Metric::new(
-                        "metco.timers_parsed".into(),
+                        Identifier::without_tags("metco.timers_parsed".into()),
                         MetricKind::Counter(timers_count),
                     ));
                 }
 
                 if gauges_count > 0 {
                     telemetry.add(Metric::new(
-                        "metco.gauges_parsed".into(),
+                        Identifier::without_tags("metco.gauges_parsed".into()),
                         MetricKind::Counter(gauges_count),
                     ));
                 }
@@ -341,7 +341,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                 let elapsed = now.elapsed();
 
                 telemetry.add(Metric::new(
-                    "metco.iteration_duration".into(),
+                    Identifier::without_tags("metco.iteration_duration".into()),
                     MetricKind::Timing(elapsed.as_nanos() as u64, TimerResolution::NanoSeconds),
                 ));
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -122,6 +122,11 @@ fn main() -> Result<(), Box<dyn Error>> {
     let cli = CLI::parse();
     init_logging(&cli);
 
+    let host = hostname::get()
+        .expect("Unable to load hostname")
+        .into_string()
+        .expect("Hostname is not valid UTF-8 string");
+
     let config: Arc<Config> = Arc::new(
         Figment::new()
             .merge(Toml::file(cli.config_path))
@@ -137,6 +142,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         registry: Registry,
         mut telemetry: Registry,
         config: Arc<Config>,
+        host: String,
     ) -> (Registry, Registry) {
         if registry.is_empty() {
             log::info!("Registry is empty, nothing to aggregate");
@@ -148,7 +154,10 @@ fn main() -> Result<(), Box<dyn Error>> {
         let new_telemetry = telemetry.new_with_gauges();
 
         telemetry.add(Metric::new(
-            Identifier::without_tags("metco.memory_usage".into()),
+            Identifier::with_tags(
+                "metco.memory_usage".into(),
+                HashMap::from([("host".into(), host)]),
+            ),
             MetricKind::Gauge(GaugeOperation::Set(
                 memory_stats::memory_stats()
                     .expect("Memory usage should be computed")
@@ -266,7 +275,7 @@ fn main() -> Result<(), Box<dyn Error>> {
         let elapsed = now.elapsed();
 
         if elapsed >= config.refresh_interval {
-            (registry, telemetry) = flush(registry, telemetry, config.clone());
+            (registry, telemetry) = flush(registry, telemetry, config.clone(), host.clone());
             now = Instant::now();
         } else {
             socket
@@ -281,7 +290,10 @@ fn main() -> Result<(), Box<dyn Error>> {
                 let now = Instant::now();
 
                 telemetry.add(Metric::new(
-                    Identifier::without_tags("metco.bytes_read".into()),
+                    Identifier::with_tags(
+                        "metco.bytes_read".into(),
+                        HashMap::from([("host".into(), host.clone())]),
+                    ),
                     MetricKind::Counter(size_read as u64),
                 ));
 
@@ -319,21 +331,30 @@ fn main() -> Result<(), Box<dyn Error>> {
 
                 if counters_count > 0 {
                     telemetry.add(Metric::new(
-                        Identifier::without_tags("metco.counters_parsed".into()),
+                        Identifier::with_tags(
+                            "metco.counters_parsed".into(),
+                            HashMap::from([("host".into(), host.clone())]),
+                        ),
                         MetricKind::Counter(counters_count),
                     ));
                 }
 
                 if timers_count > 0 {
                     telemetry.add(Metric::new(
-                        Identifier::without_tags("metco.timers_parsed".into()),
+                        Identifier::with_tags(
+                            "metco.timers_parsed".into(),
+                            HashMap::from([("host".into(), host.clone())]),
+                        ),
                         MetricKind::Counter(timers_count),
                     ));
                 }
 
                 if gauges_count > 0 {
                     telemetry.add(Metric::new(
-                        Identifier::without_tags("metco.gauges_parsed".into()),
+                        Identifier::with_tags(
+                            "metco.gauges_parsed".into(),
+                            HashMap::from([("host".into(), host.clone())]),
+                        ),
                         MetricKind::Counter(gauges_count),
                     ));
                 }
@@ -341,7 +362,10 @@ fn main() -> Result<(), Box<dyn Error>> {
                 let elapsed = now.elapsed();
 
                 telemetry.add(Metric::new(
-                    Identifier::without_tags("metco.iteration_duration".into()),
+                    Identifier::with_tags(
+                        "metco.iteration_duration".into(),
+                        HashMap::from([("host".into(), host.clone())]),
+                    ),
                     MetricKind::Timing(elapsed.as_nanos() as u64, TimerResolution::NanoSeconds),
                 ));
             }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 use std::fmt::{Display, Formatter};
+use std::hash::{Hash, Hasher};
 
 #[derive(Debug, Clone, PartialEq)]
 pub enum TimerResolution {
@@ -23,9 +24,30 @@ pub enum MetricKind {
     Gauge(GaugeOperation),
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct Identifier {
     name: String,
+    tags: HashMap<String, String>,
+}
+
+impl Identifier {
+    pub fn name(&self) -> &str {
+        &self.name
+    }
+    pub fn tags(&self) -> &HashMap<String, String> {
+        &self.tags
+    }
+}
+
+impl Hash for Identifier {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        state.write(self.name.as_bytes());
+
+        for (k, v) in self.tags.iter() {
+            state.write(k.as_bytes());
+            state.write(v.as_bytes());
+        }
+    }
 }
 
 #[derive(Debug, PartialEq)]
@@ -36,7 +58,13 @@ pub struct Metric {
 
 impl Identifier {
     pub fn without_tags(name: String) -> Self {
-        Self { name }
+        Self {
+            name,
+            tags: HashMap::default(),
+        }
+    }
+    pub fn with_tags(name: String, tags: HashMap<String, String>) -> Self {
+        Self { name, tags }
     }
 }
 
@@ -127,54 +155,55 @@ impl Statistics {
 
 #[derive(Debug)]
 pub struct TimeFrame {
-    counters: HashMap<String, Statistics>,
-    gauges: HashMap<String, i64>,
-    timings: HashMap<String, Statistics>,
-    host: String,
+    counters: HashMap<Identifier, Statistics>,
+    gauges: HashMap<Identifier, i64>,
+    timings: HashMap<Identifier, Statistics>,
 }
 
 impl TimeFrame {
-    pub fn host(&self) -> &str {
-        &self.host
-    }
-
-    pub fn counters(&self) -> &HashMap<String, Statistics> {
+    pub fn counters(&self) -> &HashMap<Identifier, Statistics> {
         &self.counters
     }
 
-    pub fn gauges(&self) -> &HashMap<String, i64> {
+    pub fn gauges(&self) -> &HashMap<Identifier, i64> {
         &self.gauges
     }
 
-    pub fn timings(&self) -> &HashMap<String, Statistics> {
+    pub fn timings(&self) -> &HashMap<Identifier, Statistics> {
         &self.timings
     }
 }
 
 #[derive(Debug)]
 pub enum OverflowingMetric {
-    Counter(String),
-    Timing(String),
+    Counter(Identifier),
+    Timing(Identifier),
 }
 
 impl Display for OverflowingMetric {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        let (kind, name) = match self {
+        let (kind, identifier) = match self {
             OverflowingMetric::Counter(name) => ("counter", name),
             OverflowingMetric::Timing(name) => ("timing", name),
         };
 
         f.write_str(kind)?;
         f.write_str(": ")?;
-        f.write_str(name)
+        f.write_str(&identifier.name)?;
+
+        if !identifier.tags.is_empty() {
+            todo!("Tags!");
+        }
+
+        Ok(())
     }
 }
 
 #[derive(Debug, Default)]
 pub struct Registry {
-    counters: HashMap<String, Vec<u64>>,
-    gauges: HashMap<String, i64>,
-    timings: HashMap<String, Vec<u64>>,
+    counters: HashMap<Identifier, Vec<u64>>,
+    gauges: HashMap<Identifier, i64>,
+    timings: HashMap<Identifier, Vec<u64>>,
 }
 
 impl Registry {
@@ -188,14 +217,11 @@ impl Registry {
         match metric.kind {
             MetricKind::Counter(value) => self
                 .counters
-                .entry(metric.identifier.name)
+                .entry(metric.identifier)
                 .or_default()
                 .push(value),
-            MetricKind::Timing(value, resolution) => self
-                .timings
-                .entry(metric.identifier.name)
-                .or_default()
-                .push(
+            MetricKind::Timing(value, resolution) => {
+                self.timings.entry(metric.identifier).or_default().push(
                     match value.checked_mul(match resolution {
                         TimerResolution::Seconds => 1_000_000_000,
                         TimerResolution::MilliSeconds => 1_000_000,
@@ -205,13 +231,14 @@ impl Registry {
                         None => return false,
                         Some(res) => res,
                     },
-                ),
+                )
+            }
             MetricKind::Gauge(operation) => match operation {
                 GaugeOperation::Set(value) => {
-                    self.gauges.insert(metric.identifier.name, value);
+                    self.gauges.insert(metric.identifier, value);
                 }
                 GaugeOperation::Modify(value) => {
-                    let val = self.gauges.entry(metric.identifier.name).or_default();
+                    let val = self.gauges.entry(metric.identifier).or_default();
 
                     match val.checked_add(value) {
                         None => return false,
@@ -219,7 +246,7 @@ impl Registry {
                     }
                 }
                 GaugeOperation::Remove => {
-                    self.gauges.remove(&metric.identifier.name);
+                    self.gauges.remove(&metric.identifier);
                 }
             },
         }
@@ -235,19 +262,17 @@ impl Registry {
     }
 
     pub fn finalize(self) -> Option<(TimeFrame, Vec<OverflowingMetric>)> {
-        let host = hostname::get().ok()?.into_string().ok()?;
-
         let mut overflowing_metrics = vec![];
 
         let time_frame = TimeFrame {
             gauges: self.gauges,
             counters: self.counters.into_iter().fold(
                 HashMap::default(),
-                |mut map, (name, list)| {
+                |mut map, (identifier, list)| {
                     if let Ok(statistics) = Statistics::new(list) {
-                        map.insert(name, statistics);
+                        map.insert(identifier, statistics);
                     } else {
-                        overflowing_metrics.push(OverflowingMetric::Counter(name));
+                        overflowing_metrics.push(OverflowingMetric::Counter(identifier));
                     }
 
                     map
@@ -265,7 +290,6 @@ impl Registry {
 
                     map
                 }),
-            host,
         };
 
         Some((time_frame, overflowing_metrics))
@@ -282,8 +306,8 @@ mod test {
         let mut registry = Registry::default();
 
         let mut map = HashMap::default();
-        map.insert("test".into(), vec![2, 7]);
-        map.insert("demo".into(), vec![32]);
+        map.insert(Identifier::without_tags("test".into()), vec![2, 7]);
+        map.insert(Identifier::without_tags("demo".into()), vec![32]);
 
         assert!(registry.add(Metric::new(
             Identifier::without_tags("test".into()),
@@ -306,8 +330,11 @@ mod test {
         let mut registry = Registry::default();
 
         let mut map = HashMap::default();
-        map.insert("test".into(), vec![2, 7_000]);
-        map.insert("demo".into(), vec![32_000_000, 64_000_000_000]);
+        map.insert(Identifier::without_tags("test".into()), vec![2, 7_000]);
+        map.insert(
+            Identifier::without_tags("demo".into()),
+            vec![32_000_000, 64_000_000_000],
+        );
 
         assert!(registry.add(Metric::new(
             Identifier::without_tags("test".into()),
@@ -334,7 +361,7 @@ mod test {
         let mut registry = Registry::default();
 
         let mut map = HashMap::default();
-        map.insert("test".into(), 10);
+        map.insert(Identifier::without_tags("test".into()), 10);
 
         assert!(registry.add(Metric::new(
             Identifier::without_tags("test".into()),
@@ -344,7 +371,7 @@ mod test {
         assert_eq!(map, registry.gauges);
 
         let mut map = HashMap::default();
-        map.insert("test".into(), -10);
+        map.insert(Identifier::without_tags("test".into()), -10);
 
         assert!(registry.add(Metric::new(
             Identifier::without_tags("test".into()),
@@ -354,7 +381,7 @@ mod test {
         assert_eq!(map, registry.gauges);
 
         let mut map = HashMap::default();
-        map.insert("test".into(), 32);
+        map.insert(Identifier::without_tags("test".into()), 32);
 
         assert!(registry.add(Metric::new(
             Identifier::without_tags("test".into()),

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -24,14 +24,25 @@ pub enum MetricKind {
 }
 
 #[derive(Debug, PartialEq)]
-pub struct Metric {
+pub struct Identifier {
     name: String,
+}
+
+#[derive(Debug, PartialEq)]
+pub struct Metric {
+    identifier: Identifier,
     kind: MetricKind,
 }
 
+impl Identifier {
+    pub fn without_tags(name: String) -> Self {
+        Self { name }
+    }
+}
+
 impl Metric {
-    pub fn new(name: String, kind: MetricKind) -> Self {
-        Self { name, kind }
+    pub fn new(identifier: Identifier, kind: MetricKind) -> Self {
+        Self { identifier, kind }
     }
 
     pub fn is_counter(&self) -> bool {
@@ -175,9 +186,16 @@ impl Registry {
 impl Registry {
     pub fn add(&mut self, metric: Metric) -> bool {
         match metric.kind {
-            MetricKind::Counter(value) => self.counters.entry(metric.name).or_default().push(value),
-            MetricKind::Timing(value, resolution) => {
-                self.timings.entry(metric.name).or_default().push(
+            MetricKind::Counter(value) => self
+                .counters
+                .entry(metric.identifier.name)
+                .or_default()
+                .push(value),
+            MetricKind::Timing(value, resolution) => self
+                .timings
+                .entry(metric.identifier.name)
+                .or_default()
+                .push(
                     match value.checked_mul(match resolution {
                         TimerResolution::Seconds => 1_000_000_000,
                         TimerResolution::MilliSeconds => 1_000_000,
@@ -187,14 +205,13 @@ impl Registry {
                         None => return false,
                         Some(res) => res,
                     },
-                )
-            }
+                ),
             MetricKind::Gauge(operation) => match operation {
                 GaugeOperation::Set(value) => {
-                    self.gauges.insert(metric.name, value);
+                    self.gauges.insert(metric.identifier.name, value);
                 }
                 GaugeOperation::Modify(value) => {
-                    let val = self.gauges.entry(metric.name).or_default();
+                    let val = self.gauges.entry(metric.identifier.name).or_default();
 
                     match val.checked_add(value) {
                         None => return false,
@@ -202,7 +219,7 @@ impl Registry {
                     }
                 }
                 GaugeOperation::Remove => {
-                    self.gauges.remove(&metric.name);
+                    self.gauges.remove(&metric.identifier.name);
                 }
             },
         }
@@ -268,9 +285,18 @@ mod test {
         map.insert("test".into(), vec![2, 7]);
         map.insert("demo".into(), vec![32]);
 
-        assert!(registry.add(Metric::new("test".into(), MetricKind::Counter(2))));
-        assert!(registry.add(Metric::new("demo".into(), MetricKind::Counter(32))));
-        assert!(registry.add(Metric::new("test".into(), MetricKind::Counter(7))));
+        assert!(registry.add(Metric::new(
+            Identifier::without_tags("test".into()),
+            MetricKind::Counter(2)
+        )));
+        assert!(registry.add(Metric::new(
+            Identifier::without_tags("demo".into()),
+            MetricKind::Counter(32)
+        )));
+        assert!(registry.add(Metric::new(
+            Identifier::without_tags("test".into()),
+            MetricKind::Counter(7)
+        )));
 
         assert_eq!(map, registry.counters)
     }
@@ -284,19 +310,19 @@ mod test {
         map.insert("demo".into(), vec![32_000_000, 64_000_000_000]);
 
         assert!(registry.add(Metric::new(
-            "test".into(),
+            Identifier::without_tags("test".into()),
             MetricKind::Timing(2, TimerResolution::NanoSeconds)
         )));
         assert!(registry.add(Metric::new(
-            "demo".into(),
+            Identifier::without_tags("demo".into()),
             MetricKind::Timing(32, TimerResolution::MilliSeconds)
         )));
         assert!(registry.add(Metric::new(
-            "test".into(),
+            Identifier::without_tags("test".into()),
             MetricKind::Timing(7, TimerResolution::MicroSeconds)
         )));
         assert!(registry.add(Metric::new(
-            "demo".into(),
+            Identifier::without_tags("demo".into()),
             MetricKind::Timing(64, TimerResolution::Seconds)
         )));
 
@@ -311,7 +337,7 @@ mod test {
         map.insert("test".into(), 10);
 
         assert!(registry.add(Metric::new(
-            "test".into(),
+            Identifier::without_tags("test".into()),
             MetricKind::Gauge(GaugeOperation::Modify(10))
         )));
 
@@ -321,7 +347,7 @@ mod test {
         map.insert("test".into(), -10);
 
         assert!(registry.add(Metric::new(
-            "test".into(),
+            Identifier::without_tags("test".into()),
             MetricKind::Gauge(GaugeOperation::Modify(-20))
         )));
 
@@ -331,14 +357,14 @@ mod test {
         map.insert("test".into(), 32);
 
         assert!(registry.add(Metric::new(
-            "test".into(),
+            Identifier::without_tags("test".into()),
             MetricKind::Gauge(GaugeOperation::Set(32))
         )));
 
         assert_eq!(map, registry.gauges);
 
         assert!(registry.add(Metric::new(
-            "test".into(),
+            Identifier::without_tags("test".into()),
             MetricKind::Gauge(GaugeOperation::Remove)
         )));
 

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -1,10 +1,11 @@
 use nom::branch::alt;
 use nom::bytes::complete::{escaped_transform, is_not, tag};
 use nom::character::complete::{char, digit1};
-use nom::combinator::{map, map_res, recognize, value};
+use nom::combinator::{map, map_res, opt, recognize, value};
 use nom::multi::separated_list1;
 use nom::sequence::tuple;
 use nom::IResult;
+use std::collections::HashMap;
 
 use crate::metrics::{GaugeOperation, Identifier, Metric, MetricKind, TimerResolution};
 
@@ -91,18 +92,64 @@ fn parse_kind(input: &str) -> IResult<&str, MetricKind> {
     alt((parse_counter, parse_timing, parse_gauge))(input)
 }
 
-fn parse_metric(input: &str) -> IResult<&str, Metric> {
+fn parse_identifier(input: &str) -> IResult<&str, Identifier> {
     let (input, name) = escaped_transform(
-        is_not("|\\"),
+        is_not("|\\;"),
         '\\',
-        alt((value("\\", tag("\\")), value("|", tag("|")))),
+        alt((
+            value("\\", tag("\\")),
+            value("|", tag("|")),
+            value(";", tag(";")),
+        )),
     )(input)?;
+
+    let (input, tags) = opt(map(
+        tuple((
+            tag(";"),
+            separated_list1(
+                tag(";"),
+                map(
+                    tuple((
+                        escaped_transform(
+                            is_not("\\="),
+                            '\\',
+                            alt((value("\\", tag("\\")), value("=", tag("=")))),
+                        ),
+                        tag("="),
+                        escaped_transform(
+                            is_not("|\\;"),
+                            '\\',
+                            alt((
+                                value("\\", tag("\\")),
+                                value(";", tag(";")),
+                                value("|", tag("|")),
+                            )),
+                        ),
+                    )),
+                    |(name, _, value)| (name, value),
+                ),
+            ),
+        )),
+        |(_, tags)| tags,
+    ))(input)?;
+
+    Ok((
+        input,
+        match tags {
+            None => Identifier::without_tags(name),
+            Some(tags) => Identifier::with_tags(name, HashMap::from_iter(tags)),
+        },
+    ))
+}
+
+fn parse_metric(input: &str) -> IResult<&str, Metric> {
+    let (input, identifier) = parse_identifier(input)?;
 
     let (input, _) = char('|')(input)?;
 
     let (input, kind) = parse_kind(input)?;
 
-    Ok((input, Metric::new(Identifier::without_tags(name), kind)))
+    Ok((input, Metric::new(identifier, kind)))
 }
 
 pub fn parse_protocol(input: &str) -> Vec<Metric> {
@@ -112,6 +159,24 @@ pub fn parse_protocol(input: &str) -> Vec<Metric> {
 #[cfg(test)]
 mod test {
     use super::*;
+    use std::collections::HashMap;
+
+    #[test]
+    fn metric_identifier_with_tags_can_be_parsed() {
+        assert_eq!(
+            Ok((
+                "|c",
+                Identifier::with_tags(
+                    "abc".into(),
+                    HashMap::from([
+                        ("tag1".into(), "value;123".into()),
+                        ("tag=2".into(), "te=st3".into())
+                    ])
+                )
+            )),
+            parse_identifier("abc;tag1=value\\;123;tag\\=2=te=st3|c")
+        );
+    }
 
     #[test]
     fn counter_can_be_parsed() {
@@ -128,10 +193,10 @@ mod test {
     fn counter_with_escaped_chars_can_be_parsed() {
         assert_eq!(
             vec![Metric::new(
-                Identifier::without_tags("a\\b|c".to_string()),
+                Identifier::without_tags("a\\b|c;".to_string()),
                 MetricKind::Counter(12),
             )],
-            parse_protocol("a\\\\b\\|c|c|12")
+            parse_protocol("a\\\\b\\|c\\;|c|12")
         );
     }
 

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -6,7 +6,7 @@ use nom::multi::separated_list1;
 use nom::sequence::tuple;
 use nom::IResult;
 
-use crate::metrics::{GaugeOperation, Metric, MetricKind, TimerResolution};
+use crate::metrics::{GaugeOperation, Identifier, Metric, MetricKind, TimerResolution};
 
 fn parse_counter(input: &str) -> IResult<&str, MetricKind> {
     let (input, _) = tag("c|")(input)?;
@@ -102,7 +102,7 @@ fn parse_metric(input: &str) -> IResult<&str, Metric> {
 
     let (input, kind) = parse_kind(input)?;
 
-    Ok((input, Metric::new(name, kind)))
+    Ok((input, Metric::new(Identifier::without_tags(name), kind)))
 }
 
 pub fn parse_protocol(input: &str) -> Vec<Metric> {
@@ -116,7 +116,10 @@ mod test {
     #[test]
     fn counter_can_be_parsed() {
         assert_eq!(
-            vec![Metric::new("abc".to_string(), MetricKind::Counter(12),)],
+            vec![Metric::new(
+                Identifier::without_tags("abc".to_string()),
+                MetricKind::Counter(12),
+            )],
             parse_protocol("abc|c|12")
         );
     }
@@ -124,7 +127,10 @@ mod test {
     #[test]
     fn counter_with_escaped_chars_can_be_parsed() {
         assert_eq!(
-            vec![Metric::new("a\\b|c".to_string(), MetricKind::Counter(12),)],
+            vec![Metric::new(
+                Identifier::without_tags("a\\b|c".to_string()),
+                MetricKind::Counter(12),
+            )],
             parse_protocol("a\\\\b\\|c|c|12")
         );
     }
@@ -141,7 +147,7 @@ mod test {
     fn gauge_can_be_parsed() {
         assert_eq!(
             vec![Metric::new(
-                "abc".to_string(),
+                Identifier::without_tags("abc".to_string()),
                 MetricKind::Gauge(GaugeOperation::Set(12)),
             )],
             parse_protocol("abc|g|12")
@@ -149,7 +155,7 @@ mod test {
 
         assert_eq!(
             vec![Metric::new(
-                "abc".to_string(),
+                Identifier::without_tags("abc".to_string()),
                 MetricKind::Gauge(GaugeOperation::Set(-12)),
             )],
             parse_protocol("abc|g|-12")
@@ -157,7 +163,7 @@ mod test {
 
         assert_eq!(
             vec![Metric::new(
-                "abc".to_string(),
+                Identifier::without_tags("abc".to_string()),
                 MetricKind::Gauge(GaugeOperation::Modify(12)),
             )],
             parse_protocol("abc|g|+=12")
@@ -165,7 +171,7 @@ mod test {
 
         assert_eq!(
             vec![Metric::new(
-                "abc".to_string(),
+                Identifier::without_tags("abc".to_string()),
                 MetricKind::Gauge(GaugeOperation::Modify(-12)),
             )],
             parse_protocol("abc|g|-=12")
@@ -173,7 +179,7 @@ mod test {
 
         assert_eq!(
             vec![Metric::new(
-                "abc".to_string(),
+                Identifier::without_tags("abc".to_string()),
                 MetricKind::Gauge(GaugeOperation::Remove),
             )],
             parse_protocol("abc|g|x")
@@ -197,7 +203,7 @@ mod test {
     fn timer_can_be_parsed() {
         assert_eq!(
             vec![Metric::new(
-                "abc".to_string(),
+                Identifier::without_tags("abc".to_string()),
                 MetricKind::Timing(123, TimerResolution::MilliSeconds),
             )],
             parse_protocol("abc|t|123")
@@ -205,7 +211,7 @@ mod test {
 
         assert_eq!(
             vec![Metric::new(
-                "abc".to_string(),
+                Identifier::without_tags("abc".to_string()),
                 MetricKind::Timing(123, TimerResolution::MilliSeconds),
             )],
             parse_protocol("abc|t|123|ms")
@@ -213,7 +219,7 @@ mod test {
 
         assert_eq!(
             vec![Metric::new(
-                "abc".to_string(),
+                Identifier::without_tags("abc".to_string()),
                 MetricKind::Timing(123, TimerResolution::Seconds),
             )],
             parse_protocol("abc|t|123|s")
@@ -221,7 +227,7 @@ mod test {
 
         assert_eq!(
             vec![Metric::new(
-                "abc".to_string(),
+                Identifier::without_tags("abc".to_string()),
                 MetricKind::Timing(123, TimerResolution::MicroSeconds),
             )],
             parse_protocol("abc|t|123|us")
@@ -229,7 +235,7 @@ mod test {
 
         assert_eq!(
             vec![Metric::new(
-                "abc".to_string(),
+                Identifier::without_tags("abc".to_string()),
                 MetricKind::Timing(123, TimerResolution::NanoSeconds),
             )],
             parse_protocol("abc|t|123|ns")


### PR DESCRIPTION
Provide support for tags
    
Each metric can now be tagged with different values. That creates partitions
within metric. One common use case is to tag each metric with a host information
from which it came.

Previously it was included by the Metco server, but now that responsibility is
now moved to the client.