### PR TITLE
Use tags for metric kind telemetry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Changed
+
+- Internal telemetry now uses single counter `metco.metrics_parsed` for parsed metrics [#16](https://github.com/zlikavac32/metco/pull/16)
+
 ## 0.4.0 - 2025-08-31
 
 ### Added

--- a/src/main.rs
+++ b/src/main.rs
@@ -332,8 +332,8 @@ fn main() -> Result<(), Box<dyn Error>> {
                 if counters_count > 0 {
                     telemetry.add(Metric::new(
                         Identifier::with_tags(
-                            "metco.counters_parsed".into(),
-                            HashMap::from([("host".into(), host.clone())]),
+                            "metco.metrics_parsed".into(),
+                            HashMap::from([("host".into(), host.clone()), ("kind".into(), "counter".into())]),
                         ),
                         MetricKind::Counter(counters_count),
                     ));
@@ -342,8 +342,8 @@ fn main() -> Result<(), Box<dyn Error>> {
                 if timers_count > 0 {
                     telemetry.add(Metric::new(
                         Identifier::with_tags(
-                            "metco.timers_parsed".into(),
-                            HashMap::from([("host".into(), host.clone())]),
+                            "metco.metrics_parsed".into(),
+                            HashMap::from([("host".into(), host.clone()), ("kind".into(), "timer".into())]),
                         ),
                         MetricKind::Counter(timers_count),
                     ));
@@ -352,8 +352,8 @@ fn main() -> Result<(), Box<dyn Error>> {
                 if gauges_count > 0 {
                     telemetry.add(Metric::new(
                         Identifier::with_tags(
-                            "metco.gauges_parsed".into(),
-                            HashMap::from([("host".into(), host.clone())]),
+                            "metco.metrics_parsed".into(),
+                            HashMap::from([("host".into(), host.clone()), ("kind".into(), "gauge".into())]),
                         ),
                         MetricKind::Counter(gauges_count),
                     ));


### PR DESCRIPTION
Instead of having three different metric names, we now have one single name `metco.metrics_parsed` which is then tagged with metric kind.