### PR TITLE
Print tags in console backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Changed
+
+- Console backend prints tags [#17](https://github.com/zlikavac32/metco/pull/17)
+
 ## 0.5.0 - 2025-08-31
 
 ### Changed

--- a/src/backend/console.rs
+++ b/src/backend/console.rs
@@ -13,7 +13,11 @@ impl Backend for Console {
             logger.info("Gauges:");
 
             time_frame.gauges().iter().for_each(|(identifier, value)| {
-                logger.info(&format!("  {} - {value}", identifier.name()))
+                logger.info(&format!(
+                    "  {} ({:?}) - {value}",
+                    identifier.name(),
+                    identifier.tags()
+                ))
             });
         }
 
@@ -24,7 +28,11 @@ impl Backend for Console {
                 .counters()
                 .iter()
                 .for_each(|(identifier, stats)| {
-                    logger.info(&format!("  {}", identifier.name()));
+                    logger.info(&format!(
+                        "  {} ({:?})",
+                        identifier.name(),
+                        identifier.tags()
+                    ));
                     logger.info(&format!("    count: {}", stats.count()));
                     logger.info(&format!("    sum: {}", stats.sum()));
                     logger.info(&format!("    std: {}", stats.std()));
@@ -46,7 +54,11 @@ impl Backend for Console {
             logger.info("Timings:");
 
             time_frame.timings().iter().for_each(|(identifier, stats)| {
-                logger.info(&format!("  {}", identifier.name()));
+                logger.info(&format!(
+                    "  {} ({:?})",
+                    identifier.name(),
+                    identifier.tags()
+                ));
                 logger.info(&format!("    count: {}", stats.count()));
                 logger.info(&format!("    sum: {}", stats.sum()));
                 logger.info(&format!("    std: {}", stats.std()));

--- a/src/main.rs
+++ b/src/main.rs
@@ -333,7 +333,10 @@ fn main() -> Result<(), Box<dyn Error>> {
                     telemetry.add(Metric::new(
                         Identifier::with_tags(
                             "metco.metrics_parsed".into(),
-                            HashMap::from([("host".into(), host.clone()), ("kind".into(), "counter".into())]),
+                            HashMap::from([
+                                ("host".into(), host.clone()),
+                                ("kind".into(), "counter".into()),
+                            ]),
                         ),
                         MetricKind::Counter(counters_count),
                     ));
@@ -343,7 +346,10 @@ fn main() -> Result<(), Box<dyn Error>> {
                     telemetry.add(Metric::new(
                         Identifier::with_tags(
                             "metco.metrics_parsed".into(),
-                            HashMap::from([("host".into(), host.clone()), ("kind".into(), "timer".into())]),
+                            HashMap::from([
+                                ("host".into(), host.clone()),
+                                ("kind".into(), "timer".into()),
+                            ]),
                         ),
                         MetricKind::Counter(timers_count),
                     ));
@@ -353,7 +359,10 @@ fn main() -> Result<(), Box<dyn Error>> {
                     telemetry.add(Metric::new(
                         Identifier::with_tags(
                             "metco.metrics_parsed".into(),
-                            HashMap::from([("host".into(), host.clone()), ("kind".into(), "gauge".into())]),
+                            HashMap::from([
+                                ("host".into(), host.clone()),
+                                ("kind".into(), "gauge".into()),
+                            ]),
                         ),
                         MetricKind::Counter(gauges_count),
                     ));


### PR DESCRIPTION
For different tags combination and same metric name, there are multiple outputs and without tags it's hard to know which is for what.