### PR TITLE
Provide 99th percentile as metric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
+### Added
+
+- 99th percentile in supported backends [#20](https://github.com/zlikavac32/metco/pull/20)
+
 ### Fixed
 
 - Percentile calculation [#19](https://github.com/zlikavac32/metco/pull/19)

--- a/src/backend/console.rs
+++ b/src/backend/console.rs
@@ -39,6 +39,7 @@ impl Backend for Console {
                     logger.info(&format!("    median: {}", stats.median()));
                     logger.info(&format!("    p75: {}", stats.percentile(75.into())));
                     logger.info(&format!("    p90: {}", stats.percentile(90.into())));
+                    logger.info(&format!("    p99: {}", stats.percentile(99.into())));
 
                     if let Some(min) = stats.min() {
                         logger.info(&format!("    min: {min}"));
@@ -65,6 +66,7 @@ impl Backend for Console {
                 logger.info(&format!("    median: {}", stats.median()));
                 logger.info(&format!("    p75: {}", stats.percentile(75.into())));
                 logger.info(&format!("    p90: {}", stats.percentile(90.into())));
+                logger.info(&format!("    p99: {}", stats.percentile(99.into())));
 
                 if let Some(min) = stats.min() {
                     logger.info(&format!("    min: {min}"));

--- a/src/backend/elastic.rs
+++ b/src/backend/elastic.rs
@@ -101,6 +101,10 @@ impl Backend for ElasticSearch {
                         format!("counter.{name}.p90"),
                         stats.percentile(90.into()).into(),
                     ),
+                    (
+                        format!("counter.{name}.p99"),
+                        stats.percentile(99.into()).into(),
+                    ),
                 ]);
 
                 if let Some(min) = stats.min() {
@@ -134,6 +138,10 @@ impl Backend for ElasticSearch {
                 (
                     format!("timing.{name}.p90"),
                     stats.percentile(90.into()).into(),
+                ),
+                (
+                    format!("timing.{name}.p99"),
+                    stats.percentile(99.into()).into(),
                 ),
             ]);
 

--- a/src/backend/postgresql.rs
+++ b/src/backend/postgresql.rs
@@ -226,6 +226,14 @@ impl Backend for PostgreSQL {
                     stats.percentile(90.into()) as f64,
                     &logger,
                 );
+                self.insert(
+                    time,
+                    MetricKind::Counter,
+                    &format!("{name}.p99"),
+                    tags,
+                    stats.percentile(99.into()) as f64,
+                    &logger,
+                );
 
                 if let Some(min) = stats.min() {
                     self.insert(
@@ -302,6 +310,14 @@ impl Backend for PostgreSQL {
                 &format!("{name}.p90"),
                 tags,
                 stats.percentile(90.into()) as f64,
+                &logger,
+            );
+            self.insert(
+                time,
+                MetricKind::Timer,
+                &format!("{name}.p99"),
+                tags,
+                stats.percentile(99.into()) as f64,
                 &logger,
             );
 


### PR DESCRIPTION
In the future, all of the metrics will be configurable for the specific backend, but for now, all of them support 99th percentile as well.