### PR TITLE
Remove Option from min()/max() in Statistics

### DIFF
--- a/src/backend/console.rs
+++ b/src/backend/console.rs
@@ -40,14 +40,8 @@ impl Backend for Console {
                     logger.info(&format!("    p75: {}", stats.percentile(75.into())));
                     logger.info(&format!("    p90: {}", stats.percentile(90.into())));
                     logger.info(&format!("    p99: {}", stats.percentile(99.into())));
-
-                    if let Some(min) = stats.min() {
-                        logger.info(&format!("    min: {min}"));
-                    }
-
-                    if let Some(max) = stats.max() {
-                        logger.info(&format!("    max: {max}"));
-                    }
+                    logger.info(&format!("    min: {}", stats.min()));
+                    logger.info(&format!("    max: {}", stats.max()));
                 });
         }
 
@@ -67,14 +61,8 @@ impl Backend for Console {
                 logger.info(&format!("    p75: {}", stats.percentile(75.into())));
                 logger.info(&format!("    p90: {}", stats.percentile(90.into())));
                 logger.info(&format!("    p99: {}", stats.percentile(99.into())));
-
-                if let Some(min) = stats.min() {
-                    logger.info(&format!("    min: {min}"));
-                }
-
-                if let Some(max) = stats.max() {
-                    logger.info(&format!("    max: {max}"));
-                }
+                logger.info(&format!("    min: {}", stats.min()));
+                logger.info(&format!("    max: {}", stats.max()));
             });
         }
     }

--- a/src/backend/elastic.rs
+++ b/src/backend/elastic.rs
@@ -88,7 +88,7 @@ impl Backend for ElasticSearch {
             .for_each(|(identifier, stats)| {
                 let name = identifier.name();
 
-                let mut map = HashMap::from([
+                let map = HashMap::from([
                     (format!("counter.{name}.count"), stats.count().into()),
                     (format!("counter.{name}.sum"), stats.sum().into()),
                     (format!("counter.{name}.std"), stats.std().into()),
@@ -105,15 +105,9 @@ impl Backend for ElasticSearch {
                         format!("counter.{name}.p99"),
                         stats.percentile(99.into()).into(),
                     ),
+                    (format!("counter.{name}.min"), stats.min().into()),
+                    (format!("counter.{name}.max"), stats.max().into()),
                 ]);
-
-                if let Some(min) = stats.min() {
-                    map.insert(format!("counter.{name}.min"), min.into());
-                }
-
-                if let Some(max) = stats.max() {
-                    map.insert(format!("counter.{name}.max"), max.into());
-                }
 
                 self.insert(time, map, identifier.tags(), &logger);
 
@@ -126,7 +120,7 @@ impl Backend for ElasticSearch {
         time_frame.timings().iter().for_each(|(identifier, stats)| {
             let name = identifier.name();
 
-            let mut map = HashMap::from([
+            let map = HashMap::from([
                 (format!("timing.{name}.count"), stats.count().into()),
                 (format!("timing.{name}.sum"), stats.sum().into()),
                 (format!("timing.{name}.std"), stats.std().into()),
@@ -143,15 +137,9 @@ impl Backend for ElasticSearch {
                     format!("timing.{name}.p99"),
                     stats.percentile(99.into()).into(),
                 ),
+                (format!("counter.{name}.min"), stats.min().into()),
+                (format!("counter.{name}.max"), stats.max().into()),
             ]);
-
-            if let Some(min) = stats.min() {
-                map.insert(format!("timing.{name}.min"), min.into());
-            }
-
-            if let Some(max) = stats.max() {
-                map.insert(format!("timing.{name}.max"), max.into());
-            }
 
             self.insert(time, map, identifier.tags(), &logger);
 

--- a/src/backend/postgresql.rs
+++ b/src/backend/postgresql.rs
@@ -234,28 +234,22 @@ impl Backend for PostgreSQL {
                     stats.percentile(99.into()) as f64,
                     &logger,
                 );
-
-                if let Some(min) = stats.min() {
-                    self.insert(
-                        time,
-                        MetricKind::Counter,
-                        &format!("{name}.min"),
-                        tags,
-                        min as f64,
-                        &logger,
-                    );
-                }
-
-                if let Some(max) = stats.max() {
-                    self.insert(
-                        time,
-                        MetricKind::Counter,
-                        &format!("{name}.max"),
-                        tags,
-                        max as f64,
-                        &logger,
-                    );
-                }
+                self.insert(
+                    time,
+                    MetricKind::Counter,
+                    &format!("{name}.min"),
+                    tags,
+                    stats.min() as f64,
+                    &logger,
+                );
+                self.insert(
+                    time,
+                    MetricKind::Counter,
+                    &format!("{name}.max"),
+                    tags,
+                    stats.max() as f64,
+                    &logger,
+                );
 
                 logger.debug(&format!("Processed counter {name} with tags {tags:?}"));
             });
@@ -320,28 +314,22 @@ impl Backend for PostgreSQL {
                 stats.percentile(99.into()) as f64,
                 &logger,
             );
-
-            if let Some(min) = stats.min() {
-                self.insert(
-                    time,
-                    MetricKind::Timer,
-                    &format!("{name}.min"),
-                    tags,
-                    min as f64,
-                    &logger,
-                );
-            }
-
-            if let Some(max) = stats.max() {
-                self.insert(
-                    time,
-                    MetricKind::Timer,
-                    &format!("{name}.max"),
-                    tags,
-                    max as f64,
-                    &logger,
-                );
-            }
+            self.insert(
+                time,
+                MetricKind::Timer,
+                &format!("{name}.min"),
+                tags,
+                stats.min() as f64,
+                &logger,
+            );
+            self.insert(
+                time,
+                MetricKind::Timer,
+                &format!("{name}.max"),
+                tags,
+                stats.max() as f64,
+                &logger,
+            );
 
             logger.debug(&format!("Processed timing {name} with tags {tags:?}"));
         });

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -137,12 +137,18 @@ impl Statistics {
         self.list.len()
     }
 
-    pub fn min(&self) -> Option<u64> {
-        self.list.first().copied()
+    pub fn min(&self) -> u64 {
+        *self
+            .list
+            .first()
+            .expect("We asserted that list is not empty")
     }
 
-    pub fn max(&self) -> Option<u64> {
-        self.list.last().copied()
+    pub fn max(&self) -> u64 {
+        *self
+            .list
+            .last()
+            .expect("We asserted that list is not empty")
     }
 
     pub fn median(&self) -> u64 {


### PR DESCRIPTION
Since we already assert that provided list is not empty, we know for sure that min/max exist and therefore there is no need to use Option.