### PR TITLE
Split counter into counter and histograms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+## Added
+
+- Histogram metric is added and regular counter no longer has an input value [#22](https://github.com/zlikavac32/metco/pull/22)
+
 ## 0.7.0 - 2025-10-03
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Each metric can have associated tags that are used to fine tune aggregations. Ta
 
 Assigning two tags to a metric would look like `name;tag1=value1;tag2=value2`.
 
-Type can be any of `c`, `t` or `g`.
+Type can be any of `c`, `h`, `t` or `g`.
 
 Value format and optional additional fields are defined by the metric type.
 
@@ -35,10 +35,18 @@ Multiple metrics can be sent separated by `\n`. Data parsed before a parsing err
 
 ### Counters
 
-Value is always a positive natural number.
+Value is always assumed to be one. This is just a simple counter.
 
 ```
 abc|c|1234
+```
+
+### Histograms
+
+Value is always a positive natural number. Unlike `counter`, this type can have arbitrary positive value associated with it and statistics are calculated for it.
+
+```
+abc|h|1234
 ```
 
 ### Timers

--- a/src/backend/console.rs
+++ b/src/backend/console.rs
@@ -27,6 +27,21 @@ impl Backend for Console {
             time_frame
                 .counters()
                 .iter()
+                .for_each(|(identifier, value)| {
+                    logger.info(&format!(
+                        "  {} ({:?}) - {value}",
+                        identifier.name(),
+                        identifier.tags()
+                    ))
+                });
+        }
+
+        if !time_frame.histograms().is_empty() {
+            logger.info("Histograms:");
+
+            time_frame
+                .histograms()
+                .iter()
                 .for_each(|(identifier, stats)| {
                     logger.info(&format!(
                         "  {} ({:?})",

--- a/src/backend/elastic.rs
+++ b/src/backend/elastic.rs
@@ -85,34 +85,52 @@ impl Backend for ElasticSearch {
         time_frame
             .counters()
             .iter()
+            .for_each(|(identifier, value)| {
+                self.insert(
+                    time,
+                    HashMap::from([(format!("counter.{}", identifier.name()), (*value).into())]),
+                    identifier.tags(),
+                    &logger,
+                );
+
+                logger.debug(&format!(
+                    "Processed counter {} with tags {:?}",
+                    identifier.name(),
+                    identifier.tags()
+                ));
+            });
+
+        time_frame
+            .histograms()
+            .iter()
             .for_each(|(identifier, stats)| {
                 let name = identifier.name();
 
                 let map = HashMap::from([
-                    (format!("counter.{name}.count"), stats.count().into()),
-                    (format!("counter.{name}.sum"), stats.sum().into()),
-                    (format!("counter.{name}.std"), stats.std().into()),
-                    (format!("counter.{name}.median"), stats.median().into()),
+                    (format!("histogram.{name}.count"), stats.count().into()),
+                    (format!("histogram.{name}.sum"), stats.sum().into()),
+                    (format!("histogram.{name}.std"), stats.std().into()),
+                    (format!("histogram.{name}.median"), stats.median().into()),
                     (
-                        format!("counter.{name}.p75"),
+                        format!("histogram.{name}.p75"),
                         stats.percentile(75.into()).into(),
                     ),
                     (
-                        format!("counter.{name}.p90"),
+                        format!("histogram.{name}.p90"),
                         stats.percentile(90.into()).into(),
                     ),
                     (
-                        format!("counter.{name}.p99"),
+                        format!("histogram.{name}.p99"),
                         stats.percentile(99.into()).into(),
                     ),
-                    (format!("counter.{name}.min"), stats.min().into()),
-                    (format!("counter.{name}.max"), stats.max().into()),
+                    (format!("histogram.{name}.min"), stats.min().into()),
+                    (format!("histogram.{name}.max"), stats.max().into()),
                 ]);
 
                 self.insert(time, map, identifier.tags(), &logger);
 
                 logger.debug(&format!(
-                    "Processed counter {name} with tags {:?}",
+                    "Processed histogram {name} with tags {:?}",
                     identifier.tags()
                 ));
             });

--- a/src/backend/postgresql.rs
+++ b/src/backend/postgresql.rs
@@ -20,6 +20,17 @@ create table metric_counters
 create index index_metric_counters on metric_counters (name, time desc);
 create index index_metric_counters_tags on metric_counters using gin (name, tags, time);
 
+create table metric_histograms
+(
+    name  text        not null,
+    time  timestamptz not null,
+    value float8      not null,
+    tags  jsonb       not null
+);
+
+create index index_metric_histograms on metric_histograms (name, time desc);
+create index index_metric_histograms_tags on metric_histograms using gin (name, tags, time);
+
 create table metric_timers
 (
     name  text        not null,
@@ -63,6 +74,23 @@ create table metric_counters
 
 create index index_metric_counters on metric_counters (name, time desc);
 create index index_metric_counters_tags on metric_counters using gin (name, tags, time);
+
+create table metric_histograms
+(
+    name  text        not null,
+    time  timestamptz not null,
+    value float8      not null,
+    tags  jsonb       not null
+)
+    with (
+        timescaledb.hypertable,
+        timescaledb.partition_column = 'time',
+        timescaledb.segmentby = 'name',
+        timescaledb.create_default_indexes = false
+        );
+
+create index index_metric_histograms on metric_histograms (name, time desc);
+create index index_metric_histograms_tags on metric_histograms using gin (name, tags, time);
 
 create table metric_timers
 (
@@ -113,6 +141,7 @@ impl Debug for PostgreSQL {
 enum MetricKind {
     Gauge,
     Counter,
+    Histogram,
     Timer,
 }
 
@@ -133,6 +162,7 @@ impl PostgreSQL {
         let table_name = match metric_kind {
             MetricKind::Gauge => "metric_gauges",
             MetricKind::Counter => "metric_counters",
+            MetricKind::Histogram => "metric_Histograms",
             MetricKind::Timer => "metric_timers",
         };
 
@@ -174,13 +204,33 @@ impl Backend for PostgreSQL {
         time_frame
             .counters()
             .iter()
+            .for_each(|(identifier, value)| {
+                self.insert(
+                    time,
+                    MetricKind::Counter,
+                    identifier.name(),
+                    identifier.tags(),
+                    *value as f64,
+                    &logger,
+                );
+
+                logger.debug(&format!(
+                    "Processed counter {} with tags {:?}",
+                    identifier.name(),
+                    identifier.tags()
+                ));
+            });
+
+        time_frame
+            .histograms()
+            .iter()
             .for_each(|(identifier, stats)| {
                 let name = identifier.name();
                 let tags = identifier.tags();
 
                 self.insert(
                     time,
-                    MetricKind::Counter,
+                    MetricKind::Histogram,
                     &format!("{name}.count"),
                     tags,
                     stats.count() as f64,
@@ -188,7 +238,7 @@ impl Backend for PostgreSQL {
                 );
                 self.insert(
                     time,
-                    MetricKind::Counter,
+                    MetricKind::Histogram,
                     &format!("{name}.sum"),
                     tags,
                     stats.sum() as f64,
@@ -196,7 +246,7 @@ impl Backend for PostgreSQL {
                 );
                 self.insert(
                     time,
-                    MetricKind::Counter,
+                    MetricKind::Histogram,
                     &format!("{name}.std"),
                     tags,
                     stats.std(),
@@ -204,7 +254,7 @@ impl Backend for PostgreSQL {
                 );
                 self.insert(
                     time,
-                    MetricKind::Counter,
+                    MetricKind::Histogram,
                     &format!("{name}.median"),
                     tags,
                     stats.median() as f64,
@@ -212,7 +262,7 @@ impl Backend for PostgreSQL {
                 );
                 self.insert(
                     time,
-                    MetricKind::Counter,
+                    MetricKind::Histogram,
                     &format!("{name}.p75"),
                     tags,
                     stats.percentile(75.into()) as f64,
@@ -220,7 +270,7 @@ impl Backend for PostgreSQL {
                 );
                 self.insert(
                     time,
-                    MetricKind::Counter,
+                    MetricKind::Histogram,
                     &format!("{name}.p90"),
                     tags,
                     stats.percentile(90.into()) as f64,
@@ -228,7 +278,7 @@ impl Backend for PostgreSQL {
                 );
                 self.insert(
                     time,
-                    MetricKind::Counter,
+                    MetricKind::Histogram,
                     &format!("{name}.p99"),
                     tags,
                     stats.percentile(99.into()) as f64,
@@ -236,7 +286,7 @@ impl Backend for PostgreSQL {
                 );
                 self.insert(
                     time,
-                    MetricKind::Counter,
+                    MetricKind::Histogram,
                     &format!("{name}.min"),
                     tags,
                     stats.min() as f64,
@@ -244,14 +294,14 @@ impl Backend for PostgreSQL {
                 );
                 self.insert(
                     time,
-                    MetricKind::Counter,
+                    MetricKind::Histogram,
                     &format!("{name}.max"),
                     tags,
                     stats.max() as f64,
                     &logger,
                 );
 
-                logger.debug(&format!("Processed counter {name} with tags {tags:?}"));
+                logger.debug(&format!("Processed histogram {name} with tags {tags:?}"));
             });
 
         time_frame.timings().iter().for_each(|(identifier, stats)| {

--- a/src/main.rs
+++ b/src/main.rs
@@ -294,7 +294,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                         "metco.bytes_read".into(),
                         HashMap::from([("host".into(), host.clone())]),
                     ),
-                    MetricKind::Counter(size_read as u64),
+                    MetricKind::Histogram(size_read as u64),
                 ));
 
                 let payload = match std::str::from_utf8(&buff[..size_read]) {
@@ -310,6 +310,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                 let (metrics, rest) = protocol::parse_protocol(payload);
 
                 let mut counters_count = 0;
+                let mut histograms_count = 0;
                 let mut timers_count = 0;
                 let mut gauges_count = 0;
 
@@ -318,6 +319,8 @@ fn main() -> Result<(), Box<dyn Error>> {
 
                     if metric.is_counter() {
                         counters_count += 1;
+                    } else if metric.is_histogram() {
+                        histograms_count += 1;
                     } else if metric.is_timer() {
                         timers_count += 1;
                     } else if metric.is_gauge() {
@@ -337,7 +340,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                             "metco.bytes_not_parsed".into(),
                             HashMap::from([("host".into(), host.clone())]),
                         ),
-                        MetricKind::Counter(rest.len() as u64),
+                        MetricKind::Histogram(rest.len() as u64),
                     ));
                 }
 
@@ -350,7 +353,20 @@ fn main() -> Result<(), Box<dyn Error>> {
                                 ("kind".into(), "counter".into()),
                             ]),
                         ),
-                        MetricKind::Counter(counters_count),
+                        MetricKind::Histogram(counters_count),
+                    ));
+                }
+
+                if histograms_count > 0 {
+                    telemetry.add(Metric::new(
+                        Identifier::with_tags(
+                            "metco.metrics_parsed".into(),
+                            HashMap::from([
+                                ("host".into(), host.clone()),
+                                ("kind".into(), "histogram".into()),
+                            ]),
+                        ),
+                        MetricKind::Histogram(counters_count),
                     ));
                 }
 
@@ -363,7 +379,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                                 ("kind".into(), "timer".into()),
                             ]),
                         ),
-                        MetricKind::Counter(timers_count),
+                        MetricKind::Histogram(timers_count),
                     ));
                 }
 
@@ -376,7 +392,7 @@ fn main() -> Result<(), Box<dyn Error>> {
                                 ("kind".into(), "gauge".into()),
                             ]),
                         ),
-                        MetricKind::Counter(gauges_count),
+                        MetricKind::Histogram(gauges_count),
                     ));
                 }
 

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -19,7 +19,8 @@ pub enum GaugeOperation {
 
 #[derive(Debug, PartialEq)]
 pub enum MetricKind {
-    Counter(u64),
+    Counter,
+    Histogram(u64),
     Timing(u64, TimerResolution),
     Gauge(GaugeOperation),
 }
@@ -74,7 +75,11 @@ impl Metric {
     }
 
     pub fn is_counter(&self) -> bool {
-        matches!(self.kind, MetricKind::Counter(_))
+        matches!(self.kind, MetricKind::Counter)
+    }
+
+    pub fn is_histogram(&self) -> bool {
+        matches!(self.kind, MetricKind::Histogram(_))
     }
 
     pub fn is_timer(&self) -> bool {
@@ -166,14 +171,19 @@ impl Statistics {
 
 #[derive(Debug)]
 pub struct TimeFrame {
-    counters: HashMap<Identifier, Statistics>,
+    counters: HashMap<Identifier, u64>,
+    histograms: HashMap<Identifier, Statistics>,
     gauges: HashMap<Identifier, i64>,
     timings: HashMap<Identifier, Statistics>,
 }
 
 impl TimeFrame {
-    pub fn counters(&self) -> &HashMap<Identifier, Statistics> {
+    pub fn counters(&self) -> &HashMap<Identifier, u64> {
         &self.counters
+    }
+
+    pub fn histograms(&self) -> &HashMap<Identifier, Statistics> {
+        &self.histograms
     }
 
     pub fn gauges(&self) -> &HashMap<Identifier, i64> {
@@ -212,7 +222,8 @@ impl Display for OverflowingMetric {
 
 #[derive(Debug, Default)]
 pub struct Registry {
-    counters: HashMap<Identifier, Vec<u64>>,
+    counters: HashMap<Identifier, u64>,
+    counters_with_histogram: HashMap<Identifier, Vec<u64>>,
     gauges: HashMap<Identifier, i64>,
     timings: HashMap<Identifier, Vec<u64>>,
 }
@@ -226,8 +237,9 @@ impl Registry {
 impl Registry {
     pub fn add(&mut self, metric: Metric) -> bool {
         match metric.kind {
-            MetricKind::Counter(value) => self
-                .counters
+            MetricKind::Counter => *self.counters.entry(metric.identifier).or_default() += 1,
+            MetricKind::Histogram(value) => self
+                .counters_with_histogram
                 .entry(metric.identifier)
                 .or_default()
                 .push(value),
@@ -277,7 +289,8 @@ impl Registry {
 
         let time_frame = TimeFrame {
             gauges: self.gauges,
-            counters: self.counters.into_iter().fold(
+            counters: self.counters,
+            histograms: self.counters_with_histogram.into_iter().fold(
                 HashMap::default(),
                 |mut map, (identifier, list)| {
                     if let Ok(statistics) = Statistics::new(list) {
@@ -322,18 +335,18 @@ mod test {
 
         assert!(registry.add(Metric::new(
             Identifier::without_tags("test".into()),
-            MetricKind::Counter(2)
+            MetricKind::Histogram(2)
         )));
         assert!(registry.add(Metric::new(
             Identifier::without_tags("demo".into()),
-            MetricKind::Counter(32)
+            MetricKind::Histogram(32)
         )));
         assert!(registry.add(Metric::new(
             Identifier::without_tags("test".into()),
-            MetricKind::Counter(7)
+            MetricKind::Histogram(7)
         )));
 
-        assert_eq!(map, registry.counters)
+        assert_eq!(map, registry.counters_with_histogram)
     }
 
     #[test]
@@ -416,7 +429,7 @@ mod test {
         for i in 1..=100 {
             registry.add(Metric::new(
                 Identifier::without_tags("test".into()),
-                MetricKind::Counter(i),
+                MetricKind::Histogram(i),
             ));
         }
 
@@ -425,7 +438,7 @@ mod test {
         assert!(overflowing_metrics.is_empty());
 
         let statistics = metrics
-            .counters
+            .histograms
             .get(&Identifier::without_tags("test".into()))
             .expect("Metric `test` should exist");
 

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -10,10 +10,16 @@ use nom::IResult;
 use std::collections::HashMap;
 
 fn parse_counter(input: &str) -> IResult<&str, MetricKind> {
-    let (input, _) = tag("c|")(input)?;
+    let (input, _) = tag("c")(input)?;
+
+    Ok((input, MetricKind::Counter))
+}
+
+fn parse_histogram(input: &str) -> IResult<&str, MetricKind> {
+    let (input, _) = tag("h|")(input)?;
 
     fn into_u64(input: &str) -> Result<MetricKind, std::num::ParseIntError> {
-        Ok(MetricKind::Counter(input.parse::<u64>()?))
+        Ok(MetricKind::Histogram(input.parse::<u64>()?))
     }
 
     map_res(digit1, into_u64)(input)
@@ -89,7 +95,7 @@ fn parse_gauge(input: &str) -> IResult<&str, MetricKind> {
 }
 
 fn parse_kind(input: &str) -> IResult<&str, MetricKind> {
-    alt((parse_counter, parse_timing, parse_gauge))(input)
+    alt((parse_counter, parse_histogram, parse_timing, parse_gauge))(input)
 }
 
 fn parse_identifier(input: &str) -> IResult<&str, Identifier> {
@@ -200,11 +206,11 @@ mod test {
             (
                 vec![Metric::new(
                     Identifier::without_tags("abc".to_string()),
-                    MetricKind::Counter(12),
+                    MetricKind::Counter,
                 )],
                 None
             ),
-            parse_protocol("abc|c|12")
+            parse_protocol("abc|c")
         );
     }
 
@@ -214,20 +220,48 @@ mod test {
             (
                 vec![Metric::new(
                     Identifier::without_tags("a\\b|c;".to_string()),
-                    MetricKind::Counter(12),
+                    MetricKind::Counter,
                 )],
                 None,
             ),
-            parse_protocol("a\\\\b\\|c\\;|c|12")
+            parse_protocol("a\\\\b\\|c\\;|c")
         );
     }
 
     #[test]
-    fn counter_with_very_big_number_is_not_parsed_but_does_not_crash_program() {
+    fn histogram_can_be_parsed() {
         assert_eq!(
-            (vec![], Some("abc|c|123456789123456789123456789123456789123456789123456789123456789123456789".into())),
+            (
+                vec![Metric::new(
+                    Identifier::without_tags("abc".to_string()),
+                    MetricKind::Histogram(12),
+                )],
+                None
+            ),
+            parse_protocol("abc|h|12")
+        );
+    }
+
+    #[test]
+    fn histogram_with_escaped_chars_can_be_parsed() {
+        assert_eq!(
+            (
+                vec![Metric::new(
+                    Identifier::without_tags("a\\b|c;".to_string()),
+                    MetricKind::Histogram(12),
+                )],
+                None,
+            ),
+            parse_protocol("a\\\\b\\|c\\;|h|12")
+        );
+    }
+
+    #[test]
+    fn histogram_with_very_big_number_is_not_parsed_but_does_not_crash_program() {
+        assert_eq!(
+            (vec![], Some("abc|h|123456789123456789123456789123456789123456789123456789123456789123456789".into())),
             parse_protocol(
-            "abc|c|123456789123456789123456789123456789123456789123456789123456789123456789"
+            "abc|h|123456789123456789123456789123456789123456789123456789123456789123456789"
         )
         );
     }


### PR DESCRIPTION
Simple counters are used when there is always +1 increment, and histograms are used for arbitrary positive increment.

When regular counter is used, there is no need for other statistics like `min`, `max`.